### PR TITLE
Don't search for missing assets

### DIFF
--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -19,7 +19,7 @@ class LabServerApp(ServerApp):
 
     def start(self):
         add_handlers(self.web_app, self.lab_config)
-        ServerApp.start(self)
+        super().start()
 
 
 main = LabServerApp.launch_instance

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -83,14 +83,6 @@ class LabHandler(JupyterHandler):
                 except Exception as e:
                     print(e)
 
-        # Handle error when the assets are not available locally.
-        local_index = os.path.join(config.static_dir, 'index.html')
-        if config.static_dir and not os.path.exists(local_index):
-            self.write(self.render_template(
-                'error.html', static_dir=config.static_dir
-            ))
-            return
-
         # Write the template with the config.
         self.write(self.render_template('index.html', page_config=page_config))
 

--- a/jupyterlab_server/index.html
+++ b/jupyterlab_server/index.html
@@ -1,13 +1,7 @@
-<!DOCTYPE html>
-<!--
-Copyright (c) Jupyter Development Team.
-Distributed under the terms of the Modified BSD License.
--->
-<html>
-
+<!doctype html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
-
   <title>{% block title %}{{page_title}}{% endblock %}</title>
 
   {% block stylesheet %}
@@ -25,7 +19,8 @@ Distributed under the terms of the Modified BSD License.
     "publicUrl": "{{ public_url }}"
   }</script>
 
-  {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="{{ base_url }}static/base/images/favicon.ico">{% endblock %}
+  {% block favicon %}
+  {% endblock %}
 
   {% for js_file in js_files %}
   <script src="{{ js_file }}" type="text/javascript" charset="utf-8"></script>
@@ -38,31 +33,16 @@ Distributed under the terms of the Modified BSD License.
 
 <body>
 
-<script type="text/javascript">
-  function _remove_token_from_url() {
-    if (window.location.search.length <= 1) {
-      return;
-    }
-    var search_parameters = window.location.search.slice(1).split('&');
-    for (var i = 0; i < search_parameters.length; i++) {
-      if (search_parameters[i].split('=')[0] === 'token') {
-        // remote token from search parameters
-        search_parameters.splice(i, 1);
-        var new_search = '';
-        if (search_parameters.length) {
-          new_search = '?' + search_parameters.join('&');
-        }
-        var new_url = window.location.origin +
-                      window.location.pathname +
-                      new_search +
-                      window.location.hash;
-        window.history.replaceState({}, "", new_url);
-        return;
+  <script type="text/javascript">
+    // Remove token from URL.
+    (function () {
+      var parsedUrl = new URL(window.location.href);
+      if (parsedUrl.searchParams.get('token')) {
+        parsedUrl.searchParams.delete('token');
+        window.history.replaceState({ }, '', parsedUrl.href);
       }
-    }
-  }
-  _remove_token_from_url();
-</script>
+    })();
+  </script>
 
 </body>
 


### PR DESCRIPTION
One correction: we aren't guaranteed index.html is in the static directory, since it is a *template*, not a static asset built. Since we don't really know what is going to be in the static directory, we just remove the check altogether. An app that wants a check can implement it in a subclass when it knows what to look for.

Two simplifications: 1. use python 3 super(), and rewrite the js function using modern apis.

~~I still want to test this before merging....~~ (ready for review)