### PR TITLE
Fixed mangling of urls in theme .css files when `base_url` is set

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -250,12 +250,13 @@ def add_handlers(web_app, config):
 
     # Handle local themes.
     if config.themes_dir:
-        themes_path = ujoin(base_url, config.themes_url, '(.*)')
+        themes_url = ujoin(base_url, config.themes_url)
+        themes_path = ujoin(themes_url, '(.*)')
         handlers.append((
             themes_path,
             ThemesHandler,
             {
-                'themes_url': config.themes_url,
+                'themes_url': themes_url,
                 'path': config.themes_dir,
                 'no_cache_paths': no_cache_paths
             }


### PR DESCRIPTION
Currently, local asset urls in a theme's `.css` files are not getting mangled correctly when an application's `base_url` is set. This PR fixes that by ensuring that the `base_url` gets prepended to all mangled `.css` urls.

I came across this bug when I was trying to write some CI tests for external theme extensions using `jupyterlab.browser_check` (see jupyterlab/theme-cookiecutter-ts#9). `browser_check` sets `base_url` to `/foo/`.

Also, I just now updated all my `jupyter*` repos to HEAD and tested the issue out again. The new [auto-minify stuff](https://github.com/jupyterlab/jupyterlab/blob/530c1a3737ee283ffa48bd4cb69003fdcd557886/buildutils/src/build.ts#L152) in JupyterLab `1.0.0a1`, while lovely, won't replace all `.css` urls in all cases, so this bug still needs to get fixed.