### PR TITLE
Parse URL-formatted metadata_id in workspace handler

### DIFF
--- a/jupyterlab_server/workspaces_handler.py
+++ b/jupyterlab_server/workspaces_handler.py
@@ -161,6 +161,7 @@ class WorkspacesHandler(APIHandler):
         metadata_id = workspace['metadata']['id']
         metadata_id = (metadata_id if metadata_id.startswith('/')
                        else '/' + metadata_id)
+        metadata_id = urllib.parse.unquote(metadata_id)
         if metadata_id != '/' + space_name:
             message = ('Workspace metadata ID mismatch: expected %r got %r'
                        % (space_name, metadata_id))


### PR DESCRIPTION
When using the kube-spawner with jupyterhub and the AzureAD authenticator, we see a lot of 400-errors in the browser console:

```
Error: Invalid response: 400 Bad Request
```

This could also happen when working in a notebook, randomly disconnecting the user-session. The user is then immediately reconnected, so no data is actually lost. However this is annoying and can be scary to some users.

From the pod logs the origin of this issue become more clear:

```
[W 2019-05-20 10:23:04.028 SingleUserLabApp web:1782] 400 PUT /user/thomas%20fredriksen/lab/api/workspaces/user/thomas%20fredriksen/lab?1558347783909 (10.12.2.1): Workspace metadata ID mismatch: expected 'user/thomas fredriksen/lab' got '/user/thomas%20fredriksen/lab'
```

From this, it appears that the url-encoded `metadata_id`-variable is not matching the workspace name. The space name is set based on the user. For me, this name comes from AzureAD and is thus set to `thomas fredriksen`, including the space. However, from the log, we can see that the space is substituted with the space url-token `%20`.

In  this PR, a single line is added to ensure the `metadata_id` is decoded to an utf8-string which matches the workspace name.