### PR TITLE
ensure the 'WHICH' command returns absolute path instead of relative path

### DIFF
--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -59,7 +59,7 @@ def which(command, env=None):
             raise ValueError(msg)
         raise ValueError('The command was not found or was not ' +
                 'executable: %s.' % command)
-    return command_with_path
+    return os.path.abspath(command_with_path)
 
 
 class Process(object):


### PR DESCRIPTION
WHICH command returns relative path when running in directory where the binary is and this causes errors in labextension install because we try to execute this relative path in a temporary directory.  Correction is making sure absolute path is returned (consistent with documentation).