### PR TITLE
fix page config escaping

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -92,7 +92,7 @@ class LabHandler(JupyterHandler):
 
         # JSON escape Python values in page_config
         for key, value in page_config.items():
-            page_config[key] = json.dumps(value)[1:-1]
+            page_config[key] = json.dumps(str(value))[1:-1]
 
         # Load the current page config file if available.
         page_config_file = os.path.join(settings_dir, 'page_config.json')

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -90,6 +90,10 @@ class LabHandler(JupyterHandler):
             full_url = ujoin(base_url, getattr(config, name))
             page_config[full_name] = full_url
 
+        # JSON escape Python values in page_config
+        for key, value in page_config.items():
+            page_config[key] = json.dumps(value)[1:-1]
+
         # Load the current page config file if available.
         page_config_file = os.path.join(settings_dir, 'page_config.json')
         if os.path.exists(page_config_file):


### PR DESCRIPTION
Properly escape strings for JSON data, to resolve issue https://github.com/jupyterlab/jupyterlab/issues/7008 This PR takes the approach of explicitly converting all values to String to prevent issues with non-string in JSON output like boolean, and then printing them as JSON string. The outer quotes are stripped, as they are added in the index.html templating later on.