### PR TITLE
Escape template values in Jinja

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -90,10 +90,6 @@ class LabHandler(JupyterHandler):
             full_url = ujoin(base_url, getattr(config, name))
             page_config[full_name] = full_url
 
-        # JSON escape Python values in page_config
-        for key, value in page_config.items():
-            page_config[key] = json.dumps(str(value))[1:-1]
-
         # Load the current page config file if available.
         page_config_file = os.path.join(settings_dir, 'page_config.json')
         if os.path.exists(page_config_file):

--- a/jupyterlab_server/templates/error.html
+++ b/jupyterlab_server/templates/error.html
@@ -8,7 +8,7 @@ Distributed under the terms of the Modified BSD License.
 <head>
   <meta charset="utf-8">
 
-  <title>{% block title %}{{page_title}}{% endblock %}</title>
+  <title>{% block title %}{{page_title | escape}{% endblock %}</title>
 
   {% block favicon %}<link rel="shortcut icon" type="image/x-icon" href="/static/base/images/favicon.ico">{% endblock %}
 
@@ -28,13 +28,13 @@ div#header, div#site {
 
 <div class="error">
     {% block h1_error %}
-    <h1>{{status_code}} : {{status_message}}</h1>
+    <h1>{{status_code | escape }} : {{status_message | escape }}</h1>
     {% endblock h1_error %}
     {% block error_detail %}
     {% if message %}
     <p>The error was:</p>
     <div class="traceback-wrapper">
-    <pre class="traceback">{{message}}</pre>
+    <pre class="traceback">{{message | escape }}</pre>
     </div>
     {% endif %}
     {% endblock %}
@@ -48,7 +48,7 @@ window.onload = function () {
   var tb = document.getElementsByClassName('traceback')[0];
   tb.scrollTop = tb.scrollHeight;
   {% if message %}
-  console.error("{{message}}")
+  console.error("{{message | escape}}")
   {% endif %}
 };
 </script>

--- a/jupyterlab_server/templates/index.html
+++ b/jupyterlab_server/templates/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>{% block title %}{{page_title}}{% endblock %}</title>
+  <title>{% block title %}{{page_title | escape }}{% endblock %}</title>
 
   {% block stylesheet %}
     {% for css_file in css_files %}
-      <link href="{{ css_file }}" rel="stylesheet">
+      <link href="{{ css_file | urlencode }}" rel="stylesheet">
     {% endfor %}
   {% endblock %}
 
@@ -23,7 +23,7 @@
   {% endblock %}
 
   {% for js_file in js_files %}
-  <script src="{{ js_file }}" type="text/javascript" charset="utf-8"></script>
+  <script src="{{ js_file | urlencode }}" type="text/javascript" charset="utf-8"></script>
   {% endfor %}
 
   {% block meta %}

--- a/jupyterlab_server/templates/index.html
+++ b/jupyterlab_server/templates/index.html
@@ -10,14 +10,15 @@
     {% endfor %}
   {% endblock %}
 
-  <script id="jupyter-config-data" type="application/json">{
-    {% for key, value in page_config.items() -%}
-    "{{ key }}": "{{ value }}",
-    {% endfor -%}
-    "baseUrl": "{{ base_url }}",
-    "wsUrl": "{{ ws_url }}",
-    "staticUrl": "{{ static_url }}"
-  }</script>
+{# Copy so we do not modify the page_config with updates. #}
+{% set page_config_full = page_config.copy() %}
+
+{# Set a dummy variable - we just want the side effect of the update. #}
+{% set _ = page_config_full.update(baseUrl=base_url, wsUrl=ws_url, staticUrl=static_url) %}
+
+  <script id="jupyter-config-data" type="application/json">
+    {{ page_config_full | tojson }}
+  </script>
 
   {% block favicon %}
   {% endblock %}


### PR DESCRIPTION
This escapes the values that go into the default template using the Jinja escaping functions.

It reverts #73 to prevent double-escaping.