### PR TITLE
Require jinja2 2.10+ to fix extra escaping

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if 'setuptools' in sys.modules:
         'json5',
         'jsonschema>=3.0.1',
         'notebook>=4.2.0',
+        'jinja2>=2.10'
     ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a requirement on `jinja2` 2.10+ to pick up https://github.com/pallets/jinja/pull/718.  Compliment to https://github.com/jupyterlab/jupyterlab/pull/7055.