### PR TITLE
Fix URL prefixing for absolute URLs

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -90,7 +90,10 @@ class LabHandler(JupyterHandler):
             if not name.endswith('_url'):
                 continue
             full_name = _camelCase('full_' + name)
-            full_url = ujoin(base_url, getattr(config, name))
+            full_url = getattr(config, name)
+            if not is_url(full_url):
+                # Relative URL will be prefixed with base_url
+                full_url = ujoin(base_url, full_url)
             page_config[full_name] = full_url
 
         # Load the current page config file if available.


### PR DESCRIPTION
Full explanation of the issue: https://github.com/jupyterlab/jupyterlab/issues/7915

The current behavior is to prefix EVERY url with `base_url`. If the URL is not relative, for example a CDN one, it'll result in an invalid URL.

There were no tests testing `LabHandler`, so I didn't add any.