### PR TITLE
Black and White Listings Handler

### DIFF
--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -15,16 +15,16 @@ class LabServerApp(ServerApp):
     default_url = Unicode('/lab',
                           help='The default URL to redirect to from `/`')
 
-    blacklist_uri = Unicode('', config=True,
+    lab_config = LabConfig()
+
+    blacklist_uris = Unicode('', config=True,
         help="A list of comma-separated URIs to get the blacklist")
 
-    whitelist_uri = Unicode('', config=True,
+    whitelist_uris = Unicode('', config=True,
         help="A list of comma-separated URIs to get the whitelist")
 
     listings_refresh_ms = Integer(1000 * 60, config=True,
         help="The interval delay in milliseconds to refresh the lists")
-
-    lab_config = LabConfig()
 
     def start(self):
         add_handlers(self.web_app, self.lab_config)

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -23,8 +23,8 @@ class LabServerApp(ServerApp):
     whitelist_uris = Unicode('', config=True,
         help="A list of comma-separated URIs to get the whitelist")
 
-    listings_refresh_ms = Integer(1000 * 60 * 5, config=True,
-        help="The interval delay in milliseconds to refresh the lists")
+    listings_refresh_seconds = Integer(60 * 60, config=True,
+        help="The interval delay in seconds to refresh the lists")
 
     listings_request_options = Dict({}, config=True,
         help="The optional kwargs to use for the listings HTTP requests \

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -4,7 +4,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import Unicode, Integer
+from traitlets import Unicode, Integer, Dict
 
 from .server import ServerApp
 from .handlers import add_handlers, LabConfig
@@ -25,6 +25,10 @@ class LabServerApp(ServerApp):
 
     listings_refresh_ms = Integer(1000 * 60, config=True,
         help="The interval delay in milliseconds to refresh the lists")
+
+    listings_request_options = Dict({}, config=True,
+        help="The optional kwargs to use for the listings HTTP requests \
+            as described on https://2.python-requests.org/en/v2.7.0/api/#requests.request")
 
     def start(self):
         add_handlers(self.web_app, self.lab_config)

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -16,13 +16,13 @@ class LabServerApp(ServerApp):
                           help='The default URL to redirect to from `/`')
 
     blacklist_uri = Unicode('', config=True,
-        help="The default URI to get the black list")
+        help="A list of comma-separated URIs to get the blacklist")
 
     whitelist_uri = Unicode('', config=True,
-        help="The default URI to get the white list")
+        help="A list of comma-separated URIs to get the whitelist")
 
     listings_refresh_ms = Integer(1000 * 60, config=True,
-        help="The interval time in milliseconds to refresh the lisings")
+        help="The interval delay in milliseconds to refresh the lists")
 
     lab_config = LabConfig()
 

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -15,6 +15,12 @@ class LabServerApp(ServerApp):
     default_url = Unicode('/lab',
                           help='The default URL to redirect to from `/`')
 
+    blacklist_uri = Unicode('', config=True,
+        help="The default URI to get the black list")
+
+    whitelist_uri = Unicode('', config=True,
+        help="The default URI to get the white list")
+
     lab_config = LabConfig()
 
     def start(self):

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -4,7 +4,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from traitlets import Unicode
+from traitlets import Unicode, Integer
 
 from .server import ServerApp
 from .handlers import add_handlers, LabConfig
@@ -20,6 +20,9 @@ class LabServerApp(ServerApp):
 
     whitelist_uri = Unicode('', config=True,
         help="The default URI to get the white list")
+
+    listings_refresh_ms = Integer(1000 * 60, config=True,
+        help="The interval time in milliseconds to refresh the lisings")
 
     lab_config = LabConfig()
 

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -23,7 +23,7 @@ class LabServerApp(ServerApp):
     whitelist_uris = Unicode('', config=True,
         help="A list of comma-separated URIs to get the whitelist")
 
-    listings_refresh_ms = Integer(1000 * 60, config=True,
+    listings_refresh_ms = Integer(1000 * 60 * 5, config=True,
         help="The interval delay in milliseconds to refresh the lists")
 
     listings_request_options = Dict({}, config=True,

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -306,8 +306,7 @@ def add_handlers(web_app, config):
     whitelist_uris = settings_config.get('whitelist_uris', '')
 
     if (blacklist_uris) and (whitelist_uris):
-        raise Exception('Simultaneous blacklist_uris and whitelist_uris is not supported. Please define only one of those.')
-        # TODO(@echarles) Force exit here.
+        print('Simultaneous blacklist_uris and whitelist_uris is not supported. Please define only one of those.')
         import sys
         sys.exit(-1)
 

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -322,7 +322,6 @@ def add_handlers(web_app, config):
     if whitelist_uris:
         ListingsHandler.whitelist_uris = set(whitelist_uris.split(','))
     
-    # TODO(@echarles) Get the log function and pass it to fetch_listings
     fetch_listings(None)
 
     handlers.append((listings_path, ListingsHandler, {}))

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -310,6 +310,14 @@ def add_handlers(web_app, config):
         settings_config = web_app.settings.get('config', {}).get('LabServerApp', {})
         blacklist_uris = settings_config.get('blacklist_uris', None)
         whitelist_uris = settings_config.get('whitelist_uris', None)
+
+        if (blacklist_uris != '') and (whitelist_uris != ''):
+            raise Exception('Simultaneous blacklist_uris and whitelist_uris is not supported. Please define only one of those.')
+            # TODO(@echarles) Force exit here.
+            import sys
+            sys.exit(-1)
+
+
         ListingsHandler.listings_refresh_ms = settings_config.get('listings_refresh_ms', 1000 * 60 * 5)
         ListingsHandler.listings_request_opts = settings_config.get('listings_request_options', {})
 
@@ -323,7 +331,6 @@ def add_handlers(web_app, config):
 
         from .listings_handler import LISTINGS_URL_SUFFIX, init_listings_uris, fetch_listings
         init_listings_uris(os.path.join(config.listings_dir, LISTINGS_URL_SUFFIX))
-
         fetch_listings()
 
         handlers.append((

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -155,11 +155,6 @@ class LabConfig(HasTraits):
                                 'schemas directory. If given, a handler will '
                                 'be added for settings.'))
 
-    listings_dir = Unicode('',
-                          help=('The optional location of the settings '
-                                'listings directory. If given, a handler will '
-                                'be added for listings.'))
-
     workspaces_api_url = Unicode(help='The url path of the workspaces API.')
 
     workspaces_dir = Unicode('',
@@ -169,7 +164,7 @@ class LabConfig(HasTraits):
 
     workspaces_url = Unicode(help='The url path of the workspaces handler.')
 
-    listings_url = Unicode(help='The theme url.')
+    listings_url = Unicode(help='The listings url.')
 
     themes_url = Unicode(help='The theme url.')
 
@@ -305,32 +300,32 @@ def add_handlers(web_app, config):
             workspace_api_path, WorkspacesHandler, workspaces_config))
 
     # Handle local listings.
-    if config.listings_dir:
 
-        settings_config = web_app.settings.get('config', {}).get('LabServerApp', {})
-        blacklist_uris = settings_config.get('blacklist_uris', '')
-        whitelist_uris = settings_config.get('whitelist_uris', '')
+    settings_config = web_app.settings.get('config', {}).get('LabServerApp', {})
+    blacklist_uris = settings_config.get('blacklist_uris', '')
+    whitelist_uris = settings_config.get('whitelist_uris', '')
 
-        if (blacklist_uris != '') and (whitelist_uris != ''):
-            raise Exception('Simultaneous blacklist_uris and whitelist_uris is not supported. Please define only one of those.')
-            # TODO(@echarles) Force exit here.
-            import sys
-            sys.exit(-1)
+    if (blacklist_uris) and (whitelist_uris):
+        raise Exception('Simultaneous blacklist_uris and whitelist_uris is not supported. Please define only one of those.')
+        # TODO(@echarles) Force exit here.
+        import sys
+        sys.exit(-1)
 
-        ListingsHandler.listings_refresh_ms = settings_config.get('listings_refresh_ms', 1000 * 60 * 5)
-        ListingsHandler.listings_request_opts = settings_config.get('listings_request_options', {})
+    ListingsHandler.listings_refresh_ms = settings_config.get('listings_refresh_ms', 1000 * 60 * 5)
+    ListingsHandler.listings_request_opts = settings_config.get('listings_request_options', {})
 
-        listings_url = ujoin(base_url, config.listings_url)
-        listings_path = ujoin(listings_url, '(.*)')
+    listings_url = ujoin(base_url, config.listings_url)
+    listings_path = ujoin(listings_url, '(.*)')
 
-        if blacklist_uris:
-            ListingsHandler.blacklist_uris = set(blacklist_uris.split(','))
-        if whitelist_uris:
-            ListingsHandler.whitelist_uris = set(whitelist_uris.split(','))
+    if blacklist_uris:
+        ListingsHandler.blacklist_uris = set(blacklist_uris.split(','))
+    if whitelist_uris:
+        ListingsHandler.whitelist_uris = set(whitelist_uris.split(','))
+    
+    # TODO(@echarles) Get the log function and pass it to fetch_listings
+    fetch_listings(None)
 
-        fetch_listings()
-
-        handlers.append((listings_path, ListingsHandler, {}))
+    handlers.append((listings_path, ListingsHandler, {}))
 
     # Handle local themes.
     if config.themes_dir:

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -310,7 +310,7 @@ def add_handlers(web_app, config):
         import sys
         sys.exit(-1)
 
-    ListingsHandler.listings_refresh_ms = settings_config.get('listings_refresh_ms', 1000 * 60 * 5)
+    ListingsHandler.listings_refresh_seconds = settings_config.get('listings_refresh_seconds', 60 * 60)
     ListingsHandler.listings_request_opts = settings_config.get('listings_request_options', {})
 
     listings_url = ujoin(base_url, config.listings_url)

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -15,6 +15,7 @@ from traitlets import HasTraits, Bool, Unicode, default
 from .server import JupyterHandler, FileFindHandler, url_path_join as ujoin
 from .workspaces_handler import WorkspacesHandler
 from .settings_handler import SettingsHandler
+from .listings_handler import ListingsHandler
 from .themes_handler import ThemesHandler
 
 # -----------------------------------------------------------------------------
@@ -151,6 +152,11 @@ class LabConfig(HasTraits):
                                 'schemas directory. If given, a handler will '
                                 'be added for settings.'))
 
+    listings_dir = Unicode('',
+                          help=('The optional location of the settings '
+                                'listings directory. If given, a handler will '
+                                'be added for listings.'))
+
     workspaces_api_url = Unicode(help='The url path of the workspaces API.')
 
     workspaces_dir = Unicode('',
@@ -159,6 +165,8 @@ class LabConfig(HasTraits):
                                    'will be added for workspaces.'))
 
     workspaces_url = Unicode(help='The url path of the workspaces handler.')
+
+    listings_url = Unicode(help='The theme url.')
 
     themes_url = Unicode(help='The theme url.')
 
@@ -188,6 +196,10 @@ class LabConfig(HasTraits):
     @default('settings_url')
     def _default_settings_url(self):
         return ujoin(self.app_url, 'api', 'settings/')
+
+    @default('listings_url')
+    def _default_listings_url(self):
+        return ujoin(self.app_url, 'api', 'listings/')
 
     @default('themes_url')
     def _default_themes_url(self):
@@ -288,6 +300,20 @@ def add_handlers(web_app, config):
             base_url, config.workspaces_api_url, '(?P<space_name>.+)')
         handlers.append((
             workspace_api_path, WorkspacesHandler, workspaces_config))
+
+    # Handle local listings.
+    if config.listings_dir:
+        listings_url = ujoin(base_url, config.listings_url)
+        listings_path = ujoin(listings_url, '(.*)')
+        handlers.append((
+            listings_path,
+            ListingsHandler,
+            {
+                'listings_url': listings_url,
+                'path': config.listings_dir,
+                'no_cache_paths': no_cache_paths
+            }
+        ))
 
     # Handle local themes.
     if config.themes_dir:

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -311,7 +311,7 @@ def add_handlers(web_app, config):
         blacklist_uris = settings_config.get('blacklist_uris', None)
         whitelist_uris = settings_config.get('whitelist_uris', None)
 
-        if (blacklist_uris != '') and (whitelist_uris != ''):
+        if (blacklist_uris != None) and (whitelist_uris != None):
             raise Exception('Simultaneous blacklist_uris and whitelist_uris is not supported. Please define only one of those.')
             # TODO(@echarles) Force exit here.
             import sys

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -311,6 +311,7 @@ def add_handlers(web_app, config):
         blacklist_uris = settings_config.get('blacklist_uris', None)
         whitelist_uris = settings_config.get('whitelist_uris', None)
         ListingsHandler.listings_refresh_ms = settings_config.get('listings_refresh_ms', 1000 * 60 * 5)
+        ListingsHandler.listings_request_opts = settings_config.get('listings_request_options', {})
 
         listings_url = ujoin(base_url, config.listings_url)
         listings_path = ujoin(listings_url, '(.*)')
@@ -320,10 +321,10 @@ def add_handlers(web_app, config):
         if whitelist_uris:
             ListingsHandler.whitelist_uris = set(whitelist_uris.split(','))
 
-        from .listings_handler import LISTINGS_URL_SUFFIX, init_listings_uris, fetch_listings_uris
+        from .listings_handler import LISTINGS_URL_SUFFIX, init_listings_uris, fetch_listings
         init_listings_uris(os.path.join(config.listings_dir, LISTINGS_URL_SUFFIX))
 
-        fetch_listings_uris()
+        fetch_listings()
 
         handlers.append((
             listings_path,

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -312,7 +312,6 @@ def add_handlers(web_app, config):
 
     ListingsHandler.listings_refresh_seconds = settings_config.get('listings_refresh_seconds', 60 * 60)
     ListingsHandler.listings_request_opts = settings_config.get('listings_request_options', {})
-
     listings_url = ujoin(base_url, config.listings_url)
     listings_path = ujoin(listings_url, '(.*)')
 
@@ -322,6 +321,15 @@ def add_handlers(web_app, config):
         ListingsHandler.whitelist_uris = set(whitelist_uris.split(','))
     
     fetch_listings(None)
+
+    if len(ListingsHandler.blacklist_uris) > 0 or len(ListingsHandler.whitelist_uris) > 0:
+        from tornado import ioloop
+        ListingsHandler.pc = ioloop.PeriodicCallback(
+            lambda: fetch_listings(None),
+            callback_time=ListingsHandler.listings_refresh_seconds * 1000,
+            jitter=0.1
+            )
+        ListingsHandler.pc.start()
 
     handlers.append((listings_path, ListingsHandler, {}))
 

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -11,9 +11,47 @@ import re
 from .server import FileFindHandler
 
 import requests
-from tornado import gen, ioloop
+
 
 LISTINGS_URL_SUFFIX='@jupyterlab/extensionmanager-extension/listings.json'
+
+
+def init_listings_uris(abs_path):
+    with open(abs_path, 'rb') as fid:
+        data = fid.read().decode('utf-8')
+    listings = json.loads(data)
+    if len(ListingsHandler.blacklist_uris) == 0:
+        for b in listings['listings']['blacklist_uris']:
+            ListingsHandler.blacklist_uris.add(b)
+    if len(ListingsHandler.whitelist_uris) == 0:
+        for w in listings['listings']['whitelist_uris']:
+            ListingsHandler.whitelist_uris.add(w)
+
+
+def fetch_listings_uris():
+    print('Fetching Blacklist from {}'.format(ListingsHandler.blacklist_uris))
+    blacklist = []
+    for blacklist_uri in ListingsHandler.blacklist_uris:
+        r = requests.get(blacklist_uri)
+        j = json.loads(r.text)
+        for b in j['blacklist']:
+            blacklist.append(b)
+    ListingsHandler.blacklist = blacklist
+    print('Fetching Whitelist from {}'.format(ListingsHandler.whitelist_uris))
+    whitelist = []
+    for whitelist_uri in ListingsHandler.whitelist_uris:
+        r = requests.get(whitelist_uri)
+        j = json.loads(r.text)
+        for w in j['whitelist']:
+            whitelist.append(w)
+    ListingsHandler.whitelist = whitelist
+    j = {
+        'blacklist_uris': list(ListingsHandler.blacklist_uris),
+        'whitelist_uris': list(ListingsHandler.whitelist_uris),
+        'blacklist': ListingsHandler.blacklist,
+        'whitelist': ListingsHandler.whitelist,
+    }
+    ListingsHandler.listings = json.dumps(j)
 
 
 class ListingsHandler(FileFindHandler):
@@ -24,74 +62,22 @@ class ListingsHandler(FileFindHandler):
     blacklist = []
     whitelist = []
     listings = ''
-    initialized = False
+    pc = None
 
     def initialize(self, path, default_filename=None,
-                   no_cache_paths=None, listings_url=None):
-
-        if type(self.config['LabServerApp']['listings_refresh_ms']) == int:
-            self.listings_refresh_ms = self.config['LabServerApp']['listings_refresh_ms']
-        else:
-            self.listings_refresh_ms = 1000 * 60
+                   no_cache_paths=None):
 
         FileFindHandler.initialize(self, path,
                                    default_filename=default_filename,
                                    no_cache_paths=no_cache_paths)
-
-        if not ListingsHandler.initialized:
-
-            if type(self.config['LabServerApp']['blacklist_uris']) == str:
-                ListingsHandler.blacklist_uris = set(self.config['LabServerApp']['blacklist_uris'].split(','))
-            if type(self.config['LabServerApp']['whitelist_uris']) == str:
-                ListingsHandler.whitelist_uris = set(self.config['LabServerApp']['whitelist_uris'].split(','))
-
-            self.init_listings_uris(os.path.join(path, LISTINGS_URL_SUFFIX))
-
-            self.fetch_listings_uris()
-
-            ListingsHandler.initialized = True
-
-            self.pc = ioloop.PeriodicCallback(self.fetch_listings_uris, callback_time=self.listings_refresh_ms)
-            self.pc.start()
-
-
-    def init_listings_uris(self, abs_path):
-        with open(abs_path, 'rb') as fid:
-            data = fid.read().decode('utf-8')
-        listings = json.loads(data)
-        if len(ListingsHandler.blacklist_uris) == 0:
-            for b in listings['listings']['blacklist_uris']:
-                ListingsHandler.blacklist_uris.add(b)
-        if len(ListingsHandler.whitelist_uris) == 0:
-            for w in listings['listings']['whitelist_uris']:
-                ListingsHandler.whitelist_uris.add(w)
-
-
-    def fetch_listings_uris(self):
-        self.log.info('Fetching Blacklist from {}'.format(ListingsHandler.blacklist_uris))
-        blacklist = []
-        for ListingsHandler.blacklist_uri in ListingsHandler.blacklist_uris:
-            r = requests.get(ListingsHandler.blacklist_uri)
-            j = json.loads(r.text)
-            for b in j['blacklist']:
-                blacklist.append(b)
-        ListingsHandler.blacklist = blacklist
-        self.log.info('Fetching Whitelist from {}'.format(ListingsHandler.whitelist_uris))
-        whitelist = []
-        for ListingsHandler.whitelist_uri in ListingsHandler.whitelist_uris:
-            r = requests.get(ListingsHandler.whitelist_uri)
-            j = json.loads(r.text)
-            for w in j['whitelist']:
-                whitelist.append(w)
-        ListingsHandler.whitelist = whitelist
-        j = {
-            'blacklist_uris': list(ListingsHandler.blacklist_uris),
-            'whitelist_uris': list(ListingsHandler.whitelist_uris),
-            'blacklist': ListingsHandler.blacklist,
-            'whitelist': ListingsHandler.whitelist,
-        }
-        ListingsHandler.listings = json.dumps(j)
-
+        if len(ListingsHandler.blacklist_uris) > 0 or len(ListingsHandler.whitelist_uris) > 0:
+            from tornado import ioloop
+            ListingsHandler.pc = ioloop.PeriodicCallback(
+                fetch_listings_uris, 
+                callback_time=ListingsHandler.listings_refresh_ms,
+                jitter=0.1
+                )
+            ListingsHandler.pc.start()
 
     def get_content(self, abspath, start=None, end=None):
         """Retrieve the content of the requested resource which is located

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -28,11 +28,11 @@ def init_listings_uris(abs_path):
             ListingsHandler.whitelist_uris.add(w)
 
 
-def fetch_listings_uris():
+def fetch_listings():
     print('Fetching Blacklist from {}'.format(ListingsHandler.blacklist_uris))
     blacklist = []
     for blacklist_uri in ListingsHandler.blacklist_uris:
-        r = requests.get(blacklist_uri)
+        r = requests.request('GET', blacklist_uri, **ListingsHandler.listings_request_opts)
         j = json.loads(r.text)
         for b in j['blacklist']:
             blacklist.append(b)
@@ -40,7 +40,7 @@ def fetch_listings_uris():
     print('Fetching Whitelist from {}'.format(ListingsHandler.whitelist_uris))
     whitelist = []
     for whitelist_uri in ListingsHandler.whitelist_uris:
-        r = requests.get(whitelist_uri)
+        r = requests.request('GET', whitelist_uri, **ListingsHandler.listings_request_opts)
         j = json.loads(r.text)
         for w in j['whitelist']:
             whitelist.append(w)
@@ -62,6 +62,7 @@ class ListingsHandler(FileFindHandler):
     blacklist = []
     whitelist = []
     listings = ''
+    listings_request_opts = {}
     pc = None
 
     def initialize(self, path, default_filename=None,
@@ -73,7 +74,7 @@ class ListingsHandler(FileFindHandler):
         if len(ListingsHandler.blacklist_uris) > 0 or len(ListingsHandler.whitelist_uris) > 0:
             from tornado import ioloop
             ListingsHandler.pc = ioloop.PeriodicCallback(
-                fetch_listings_uris, 
+                fetch_listings,
                 callback_time=ListingsHandler.listings_refresh_ms,
                 jitter=0.1
                 )

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -1,0 +1,16 @@
+"""Tornado handlers for dynamic listings loading."""
+
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+from .server import FileFindHandler
+
+
+class ListingsHandler(FileFindHandler):
+    """A file handler that returns file conttent from the listings directory."""
+
+    def initialize(self, path, default_filename=None,
+                   no_cache_paths=None, listings_url=None):
+        FileFindHandler.initialize(self, path,
+                                   default_filename=default_filename,
+                                   no_cache_paths=no_cache_paths)

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -9,26 +9,75 @@ import re
 
 from .server import FileFindHandler
 
+import requests
 
-LISTINGS='@jupyterlab/extensionmanager-extension/listings.json'
+
+LISTINGS_URL_SUFFIX='@jupyterlab/extensionmanager-extension/listings.json'
+
 
 class ListingsHandler(FileFindHandler):
-    """A file handler that returns file conttent from the listings directory."""
+    """A file handler that returns file content from the listings directory."""
 
+    blacklist_uris = set()
+    whitelist_uris = set()
+    blacklist = set()
+    whitelist = set()
+    listings = ""
+    initialized = False
 
     def initialize(self, path, default_filename=None,
                    no_cache_paths=None, listings_url=None):
+
         FileFindHandler.initialize(self, path,
                                    default_filename=default_filename,
                                    no_cache_paths=no_cache_paths)
-        if type(self.config['LabServerApp']['blacklist_uri']) == str:
-            self.blacklist_uri = self.config['LabServerApp']['blacklist_uri']
-        else:
-            self.blacklist_uri = ''
-        if type(self.config['LabServerApp']['whitelist_uri']) == str:
-            self.whitelist_uri = self.config['LabServerApp']['whitelist_uri']
-        else:
-            self.whitelist_uri = ''
+
+        if not ListingsHandler.initialized:
+
+            if type(self.config['LabServerApp']['blacklist_uris']) == str:
+                ListingsHandler.blacklist_uris = set(self.config['LabServerApp']['blacklist_uris'].split(','))
+            if type(self.config['LabServerApp']['whitelist_uris']) == str:
+                ListingsHandler.whitelist_uris = set(self.config['LabServerApp']['whitelist_uris'].split(','))
+
+            self.init_listings_uris(os.path.join(path, LISTINGS_URL_SUFFIX))
+            self.fetch_listings_uris()
+
+            j = {
+                'blacklist_uris': list(ListingsHandler.blacklist_uris),
+                'whitelist_uris': list(ListingsHandler.whitelist_uris),
+                'blacklist': list(ListingsHandler.blacklist),
+                'whitelist': list(ListingsHandler.whitelist)
+            }
+            ListingsHandler.listings = json.dumps(j)
+            print(ListingsHandler.listings)
+
+            ListingsHandler.initialized = True
+
+
+    def init_listings_uris(self, abs_path):
+        with open(abs_path, 'rb') as fid:
+            data = fid.read().decode('utf-8')
+        listings = json.loads(data)
+        if len(ListingsHandler.blacklist_uris) == 0:
+            for b in listings['listings']['blacklist_uris']:
+                ListingsHandler.blacklist_uris.add(b)
+        if len(ListingsHandler.whitelist_uris) == 0:
+            for w in listings['listings']['whitelist_uris']:
+                ListingsHandler.whitelist_uris.add(w)
+
+
+    def fetch_listings_uris(self):
+        for ListingsHandler.blacklist_uri in ListingsHandler.blacklist_uris:
+            r = requests.get(ListingsHandler.blacklist_uri)
+            j = json.loads(r.text)
+            for b in j['blacklist']:
+                ListingsHandler.blacklist.add(b)
+        for ListingsHandler.whitelist_uri in ListingsHandler.whitelist_uris:
+            r = requests.get(ListingsHandler.whitelist_uri)
+            j = json.loads(r.text)
+            for w in j['whitelist']:
+                ListingsHandler.whitelist.add(w)
+
 
     def get_content(self, abspath, start=None, end=None):
         """Retrieve the content of the requested resource which is located
@@ -37,24 +86,20 @@ class ListingsHandler(FileFindHandler):
         This method should either return a byte string or an iterator
         of byte strings.
         """
-        if not abspath.endswith(LISTINGS):
+        if not abspath.endswith(LISTINGS_URL_SUFFIX):
             return FileFindHandler.get_content(abspath, start, end)
 
+        self.set_header('Content-Type', 'application/json')
         return self._get_listings()
+
 
     def get_content_size(self):
         """Retrieve the total size of the resource at the given path."""
-        if not self.absolute_path.endswith(LISTINGS):
+        if not self.absolute_path.endswith(LISTINGS_URL_SUFFIX):
             return FileFindHandler.get_content_size(self)
 
         return len(self._get_listings())
 
+
     def _get_listings(self):
-        with open(self.absolute_path, 'rb') as fid:
-            data = fid.read().decode('utf-8')
-        listings = json.loads(data)
-        if self.blacklist_uri != '':
-            listings['listings']['blacklist_uri'] = self.blacklist_uri
-        if self.whitelist_uri != '':
-            listings['listings']['whitelist_uri'] = self.whitelist_uri
-        return json.dumps(listings)
+        return ListingsHandler.listings

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -74,17 +74,6 @@ class ListingsHandler(APIHandler):
     pc = None
 
 
-    def initialize(self):
-
-        if len(ListingsHandler.blacklist_uris) > 0 or len(ListingsHandler.whitelist_uris) > 0:
-            from tornado import ioloop
-            ListingsHandler.pc = ioloop.PeriodicCallback(
-                lambda: fetch_listings(self.log),
-                callback_time=ListingsHandler.listings_refresh_seconds * 1000,
-                jitter=0.1
-                )
-            ListingsHandler.pc.start()
-
     def get(self, path):
         self.set_header('Content-Type', 'application/json')
         if path == LISTINGS_URL_SUFFIX:

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -36,7 +36,6 @@ def fetch_listings(logger):
     if len(ListingsHandler.whitelist_uris) > 0:
         whitelist = []
         for whitelist_uri in ListingsHandler.whitelist_uris:
-            print('adsf')
             logger.info('Fetching whitelist from {}'.format(ListingsHandler.whitelist_uris))
             r = requests.request('GET', whitelist_uri, **ListingsHandler.listings_request_opts)
             j = json.loads(r.text)

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -3,14 +3,58 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+import os
+import json
+import re
+
 from .server import FileFindHandler
 
 
+LISTINGS='@jupyterlab/extensionmanager-extension/listings.json'
+
 class ListingsHandler(FileFindHandler):
     """A file handler that returns file conttent from the listings directory."""
+
 
     def initialize(self, path, default_filename=None,
                    no_cache_paths=None, listings_url=None):
         FileFindHandler.initialize(self, path,
                                    default_filename=default_filename,
                                    no_cache_paths=no_cache_paths)
+        if type(self.config['LabServerApp']['blacklist_uri']) == str:
+            self.blacklist_uri = self.config['LabServerApp']['blacklist_uri']
+        else:
+            self.blacklist_uri = ''
+        if type(self.config['LabServerApp']['whitelist_uri']) == str:
+            self.whitelist_uri = self.config['LabServerApp']['whitelist_uri']
+        else:
+            self.whitelist_uri = ''
+
+    def get_content(self, abspath, start=None, end=None):
+        """Retrieve the content of the requested resource which is located
+        at the given absolute path.
+
+        This method should either return a byte string or an iterator
+        of byte strings.
+        """
+        if not abspath.endswith(LISTINGS):
+            return FileFindHandler.get_content(abspath, start, end)
+
+        return self._get_listings()
+
+    def get_content_size(self):
+        """Retrieve the total size of the resource at the given path."""
+        if not self.absolute_path.endswith(LISTINGS):
+            return FileFindHandler.get_content_size(self)
+
+        return len(self._get_listings())
+
+    def _get_listings(self):
+        with open(self.absolute_path, 'rb') as fid:
+            data = fid.read().decode('utf-8')
+        listings = json.loads(data)
+        if self.blacklist_uri != '':
+            listings['listings']['blacklist_uri'] = self.blacklist_uri
+        if self.whitelist_uri != '':
+            listings['listings']['whitelist_uri'] = self.whitelist_uri
+        return json.dumps(listings)

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -7,6 +7,7 @@ import os
 import time
 import json
 import re
+import tornado
 
 from .server import APIHandler
 
@@ -16,11 +17,15 @@ import requests
 LISTINGS_URL_SUFFIX='@jupyterlab/extensionmanager-extension/listings.json'
 
 
-def fetch_listings():
+def fetch_listings(log):
+    def log_info(message):
+        if log:
+            return log.info(message)
+        return print(message)
     if len(ListingsHandler.blacklist_uris) > 0:
         blacklist = []
         for blacklist_uri in ListingsHandler.blacklist_uris:
-            print('Fetching blacklist from {}'.format(ListingsHandler.blacklist_uris))
+            log_info('Fetching blacklist from {}'.format(ListingsHandler.blacklist_uris))
             r = requests.request('GET', blacklist_uri, **ListingsHandler.listings_request_opts)
             j = json.loads(r.text)
             for b in j['blacklist']:
@@ -29,7 +34,7 @@ def fetch_listings():
     if len(ListingsHandler.whitelist_uris) > 0:
         whitelist = []
         for whitelist_uri in ListingsHandler.whitelist_uris:
-            print('Fetching whitelist from {}'.format(ListingsHandler.whitelist_uris))
+            log_info('Fetching whitelist from {}'.format(ListingsHandler.whitelist_uris))
             r = requests.request('GET', whitelist_uri, **ListingsHandler.listings_request_opts)
             j = json.loads(r.text)
             for w in j['whitelist']:
@@ -46,20 +51,36 @@ def fetch_listings():
 class ListingsHandler(APIHandler):
     """An handler that returns the listings specs."""
 
+    """Below fields are class level fields that are accessed and populated
+    by the initialization and the fetch_listings methods.
+    Some fields are initialized before the handler creation in the 
+    handlers.py#add_handlers method.
+    Having those fields predefined reduces the guards in the methods using
+    them.
+    """
+    # The list of blacklist URIS.
     blacklist_uris = set()
+    # The list of whitelist URIS.
     whitelist_uris = set()
+    # The blacklisted extensions.
     blacklist = []
+    # The whitelisted extensions.
     whitelist = []
+    # The computed listing to be returned
+    # It will contain the uris and the listings.
     listings = ''
+    # The provider request options to be used for the request library.
     listings_request_opts = {}
+    # The PeriodicCallback that schedule the call to fetch_listings method.
     pc = None
+
 
     def initialize(self):
 
         if len(ListingsHandler.blacklist_uris) > 0 or len(ListingsHandler.whitelist_uris) > 0:
             from tornado import ioloop
             ListingsHandler.pc = ioloop.PeriodicCallback(
-                fetch_listings,
+                lambda: fetch_listings(self.log),
                 callback_time=ListingsHandler.listings_refresh_ms,
                 jitter=0.1
                 )
@@ -70,4 +91,4 @@ class ListingsHandler(APIHandler):
         if path == LISTINGS_URL_SUFFIX:
             self.write(ListingsHandler.listings)
         else:
-            self.write({})
+            raise tornado.web.HTTPError(400)

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -20,38 +20,40 @@ def init_listings_uris(abs_path):
     with open(abs_path, 'rb') as fid:
         data = fid.read().decode('utf-8')
     listings = json.loads(data)
-    if len(ListingsHandler.blacklist_uris) == 0:
-        for b in listings['listings']['blacklist_uris']:
-            ListingsHandler.blacklist_uris.add(b)
-    if len(ListingsHandler.whitelist_uris) == 0:
-        for w in listings['listings']['whitelist_uris']:
-            ListingsHandler.whitelist_uris.add(w)
+    # TODO(@echarles) Review this, as we have exclusive modes now.
+#    if len(ListingsHandler.blacklist_uris) == 0:
+#        for b in listings['listings']['blacklist_uris']:
+#            ListingsHandler.blacklist_uris.add(b)
+#    if len(ListingsHandler.whitelist_uris) == 0:
+#        for w in listings['listings']['whitelist_uris']:
+#            ListingsHandler.whitelist_uris.add(w)
 
 
 def fetch_listings():
-    print('Fetching Blacklist from {}'.format(ListingsHandler.blacklist_uris))
-    blacklist = []
-    for blacklist_uri in ListingsHandler.blacklist_uris:
-        r = requests.request('GET', blacklist_uri, **ListingsHandler.listings_request_opts)
-        j = json.loads(r.text)
-        for b in j['blacklist']:
-            blacklist.append(b)
-    ListingsHandler.blacklist = blacklist
-    print('Fetching Whitelist from {}'.format(ListingsHandler.whitelist_uris))
-    whitelist = []
-    for whitelist_uri in ListingsHandler.whitelist_uris:
-        r = requests.request('GET', whitelist_uri, **ListingsHandler.listings_request_opts)
-        j = json.loads(r.text)
-        for w in j['whitelist']:
-            whitelist.append(w)
-    ListingsHandler.whitelist = whitelist
-    j = {
+    if len(ListingsHandler.blacklist_uris) > 0:
+        blacklist = []
+        for blacklist_uri in ListingsHandler.blacklist_uris:
+            print('Fetching blacklist from {}'.format(ListingsHandler.blacklist_uris))
+            r = requests.request('GET', blacklist_uri, **ListingsHandler.listings_request_opts)
+            j = json.loads(r.text)
+            for b in j['blacklist']:
+                blacklist.append(b)
+            ListingsHandler.blacklist = blacklist
+    if len(ListingsHandler.whitelist_uris) > 0:
+        whitelist = []
+        for whitelist_uri in ListingsHandler.whitelist_uris:
+            print('Fetching whitelist from {}'.format(ListingsHandler.whitelist_uris))
+            r = requests.request('GET', whitelist_uri, **ListingsHandler.listings_request_opts)
+            j = json.loads(r.text)
+            for w in j['whitelist']:
+                whitelist.append(w)
+        ListingsHandler.whitelist = whitelist
+    ListingsHandler.listings = json.dumps({
         'blacklist_uris': list(ListingsHandler.blacklist_uris),
         'whitelist_uris': list(ListingsHandler.whitelist_uris),
         'blacklist': ListingsHandler.blacklist,
         'whitelist': ListingsHandler.whitelist,
-    }
-    ListingsHandler.listings = json.dumps(j)
+    })
 
 
 class ListingsHandler(FileFindHandler):

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -20,8 +20,8 @@ class ListingsHandler(FileFindHandler):
 
     blacklist_uris = set()
     whitelist_uris = set()
-    blacklist = set()
-    whitelist = set()
+    blacklist = []
+    whitelist = []
     listings = ""
     initialized = False
 
@@ -45,8 +45,8 @@ class ListingsHandler(FileFindHandler):
             j = {
                 'blacklist_uris': list(ListingsHandler.blacklist_uris),
                 'whitelist_uris': list(ListingsHandler.whitelist_uris),
-                'blacklist': list(ListingsHandler.blacklist),
-                'whitelist': list(ListingsHandler.whitelist)
+                'blacklist': ListingsHandler.blacklist,
+                'whitelist': ListingsHandler.whitelist,
             }
             ListingsHandler.listings = json.dumps(j)
 
@@ -70,13 +70,12 @@ class ListingsHandler(FileFindHandler):
             r = requests.get(ListingsHandler.blacklist_uri)
             j = json.loads(r.text)
             for b in j['blacklist']:
-                ListingsHandler.blacklist.add(b)
+                ListingsHandler.blacklist.append(b)            
         for ListingsHandler.whitelist_uri in ListingsHandler.whitelist_uris:
             r = requests.get(ListingsHandler.whitelist_uri)
             j = json.loads(r.text)
             for w in j['whitelist']:
-                ListingsHandler.whitelist.add(w)
-
+                ListingsHandler.whitelist.append(w)
 
     def get_content(self, abspath, start=None, end=None):
         """Retrieve the content of the requested resource which is located

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -69,17 +69,21 @@ class ListingsHandler(FileFindHandler):
 
     def fetch_listings_uris(self):
         self.log.info('Fetching Blacklist from {}'.format(ListingsHandler.blacklist_uris))
+        blacklist = []
         for ListingsHandler.blacklist_uri in ListingsHandler.blacklist_uris:
             r = requests.get(ListingsHandler.blacklist_uri)
             j = json.loads(r.text)
             for b in j['blacklist']:
-                ListingsHandler.blacklist.append(b)            
+                blacklist.append(b)
+        ListingsHandler.blacklist = blacklist
         self.log.info('Fetching Whitelist from {}'.format(ListingsHandler.whitelist_uris))
+        whitelist = []
         for ListingsHandler.whitelist_uri in ListingsHandler.whitelist_uris:
             r = requests.get(ListingsHandler.whitelist_uri)
             j = json.loads(r.text)
             for w in j['whitelist']:
-                ListingsHandler.whitelist.append(w)
+                whitelist.append(w)
+        ListingsHandler.whitelist = whitelist
         j = {
             'blacklist_uris': list(ListingsHandler.blacklist_uris),
             'whitelist_uris': list(ListingsHandler.whitelist_uris),

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -11,21 +11,23 @@ import tornado
 
 from .server import APIHandler
 
+from traitlets import Instance
+
+
 import requests
 
 
 LISTINGS_URL_SUFFIX='@jupyterlab/extensionmanager-extension/listings.json'
 
 
-def fetch_listings(log):
-    def log_info(message):
-        if log:
-            return log.info(message)
-        return print(message)
+def fetch_listings(logger):
+    if not logger:
+        from traitlets import log
+        logger = log.get_logger()
     if len(ListingsHandler.blacklist_uris) > 0:
         blacklist = []
         for blacklist_uri in ListingsHandler.blacklist_uris:
-            log_info('Fetching blacklist from {}'.format(ListingsHandler.blacklist_uris))
+            logger.info('Fetching blacklist from {}'.format(ListingsHandler.blacklist_uris))
             r = requests.request('GET', blacklist_uri, **ListingsHandler.listings_request_opts)
             j = json.loads(r.text)
             for b in j['blacklist']:
@@ -34,7 +36,8 @@ def fetch_listings(log):
     if len(ListingsHandler.whitelist_uris) > 0:
         whitelist = []
         for whitelist_uri in ListingsHandler.whitelist_uris:
-            log_info('Fetching whitelist from {}'.format(ListingsHandler.whitelist_uris))
+            print('adsf')
+            logger.info('Fetching whitelist from {}'.format(ListingsHandler.whitelist_uris))
             r = requests.request('GET', whitelist_uri, **ListingsHandler.listings_request_opts)
             j = json.loads(r.text)
             for w in j['whitelist']:

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -69,9 +69,6 @@ class ListingsHandler(APIHandler):
     blacklist = []
     # The whitelisted extensions.
     whitelist = []
-    # The computed listing to be returned
-    # It will contain the uris and the listings.
-    listings = ''
     # The provider request options to be used for the request library.
     listings_request_opts = {}
     # The PeriodicCallback that schedule the call to fetch_listings method.

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -80,7 +80,7 @@ class ListingsHandler(APIHandler):
             from tornado import ioloop
             ListingsHandler.pc = ioloop.PeriodicCallback(
                 lambda: fetch_listings(self.log),
-                callback_time=ListingsHandler.listings_refresh_ms,
+                callback_time=ListingsHandler.listings_refresh_seconds * 1000,
                 jitter=0.1
                 )
             ListingsHandler.pc.start()

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -49,7 +49,6 @@ class ListingsHandler(FileFindHandler):
                 'whitelist': list(ListingsHandler.whitelist)
             }
             ListingsHandler.listings = json.dumps(j)
-            print(ListingsHandler.listings)
 
             ListingsHandler.initialized = True
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ if 'setuptools' in sys.modules:
     setup_args['python_requires'] = '>=3.5'
     setup_args['extras_require'] = {'test': ['pytest', 'requests']}
     setup_args['install_requires'] = [
+        'requests',
         'json5',
         'jsonschema>=3.0.1',
         'notebook>=4.2.0',


### PR DESCRIPTION
This is a PR to implement Black and White listings for the Extension Manager as discussed in #7933 and #7967.

It adds a ListingsHandler that delivers the URI for the lists.

It must be seen in conjunction with https://github.com/jupyterlab/jupyterlab/pull/7989