### PR TITLE
Do not try to close the watch process file handle

### DIFF
--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -230,12 +230,6 @@ class WatchHelper(Process):
             else:
                 os.kill(proc.pid, signal.SIGTERM)
 
-        # Close stdout.
-        try:
-            self._stdout.close()
-        except Exception as e:
-            pass
-
         # Wait for the process to close.
         try:
             proc.wait()


### PR DESCRIPTION
This was causing the application to lock during shutdown when in watch mode.  Defer the file handle management to the OS during shutdown.