### PR TITLE
Kill the subprocess if it does not stop

### DIFF
--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -119,7 +119,12 @@ class Process(object):
 
         # Wait for the process to close.
         try:
-            proc.wait()
+            proc.wait(timeout=1.)
+        except TimeoutError:
+            if os.name == 'nt':
+                os.kill(proc.pid, signal.SIGBREAK)
+            else:
+                os.kill(proc.pid, signal.SIGKILL)
         finally:
             Process._procs.remove(self)
 


### PR DESCRIPTION
Our `WatchHelper` subprocesses were not responding to `SIGTERM`