### PR TITLE
Clean up terminate logic

### DIFF
--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -119,7 +119,7 @@ class Process(object):
 
         # Wait for the process to close.
         try:
-            proc.wait(timeout=1.)
+            proc.wait(timeout=2.)
         except subprocess.TimeoutExpired:
             if os.name == 'nt':
                 sig = signal.SIGBREAK

--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -120,11 +120,15 @@ class Process(object):
         # Wait for the process to close.
         try:
             proc.wait(timeout=1.)
-        except TimeoutError:
+        except subprocess.TimeoutExpired:
             if os.name == 'nt':
-                os.kill(proc.pid, signal.SIGBREAK)
+                sig = signal.SIGBREAK
             else:
-                os.kill(proc.pid, signal.SIGKILL)
+                sig = signal.SIGKILL
+
+            if proc.poll() is None:
+               os.kill(proc.pid, sig) 
+
         finally:
             Process._procs.remove(self)
 


### PR DESCRIPTION
Follow up to #88.  Our usage tests are timing out in JupyterLab.

In https://github.com/jupyterlab/jupyterlab/pull/8433 we set the kernel [`shutdown_wait_time`](https://github.com/jupyter/jupyter_client/blob/ea823fd84b4f5db0a050457b9b2cd7619e9a2d53/jupyter_client/manager.py#L66) to 1 sec, so we set the wait time here to 2 sec to give the kernels a chance to shut down.