### PR TITLE
Add last_modified and created to settings and workspace API items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
+    - 3.9-dev
+    - 3.8
     - 3.6
     - 3.5
 sudo: false

--- a/jupyterlab_server/server.py
+++ b/jupyterlab_server/server.py
@@ -22,6 +22,7 @@ try:
         GREEN_ENABLED, GREEN_OK, RED_DISABLED, RED_X
     )
     from notebook.utils import url_escape, url_path_join
+    from notebook import _tz as tz
 except ImportError:
     from jupyter_server.base.handlers import (                          # noqa
         APIHandler, FileFindHandler, json_errors, JupyterHandler
@@ -31,3 +32,4 @@ except ImportError:
     )
     from jupyter_server.serverapp import ServerApp, aliases, flags      # noqa
     from jupyter_server.utils import url_escape, url_path_join          # noqa
+    from jupyter_server import _tz as tz

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -2,7 +2,7 @@
 import json
 import os
 import shutil
-from datetime import datetime
+from strict_rfc3339 import rfc3339_to_timestamp
 
 from jupyterlab_server.tests.utils import LabTestBase, APITester
 from ..servertest import assert_http_error
@@ -83,8 +83,8 @@ class SettingsAPITest(LabTestBase):
         assert self.settings_api.put(id, dict()).status_code == 204
         data = self.settings_api.get(id).json()
         assert (
-            datetime.fromisoformat(data['created']) <=
-            datetime.fromisoformat(data['last_modified'])
+            rfc3339_to_timestamp(data['created']) <=
+            rfc3339_to_timestamp(data['last_modified'])
         ), data
 
         listing = self.settings_api.get('').json()['settings']

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -2,6 +2,7 @@
 import json
 import os
 import shutil
+from datetime import datetime
 
 from jupyterlab_server.tests.utils import LabTestBase, APITester
 from ..servertest import assert_http_error
@@ -72,11 +73,25 @@ class SettingsAPITest(LabTestBase):
 
         assert set(response_ids) == set(ids)
         assert set(response_versions) == set(versions)
+        last_modifieds = [item['last_modified'] for item in response['settings']]
+        createds = [item['created'] for item in response['settings']]
+        assert {None} == set(last_modifieds + createds)
 
     def test_patch(self):
         id = '@jupyterlab/shortcuts-extension:plugin'
 
         assert self.settings_api.put(id, dict()).status_code == 204
+        data = self.settings_api.get(id).json()
+        assert (
+            datetime.fromisoformat(data['created']) <=
+            datetime.fromisoformat(data['last_modified'])
+        ), data
+
+        listing = self.settings_api.get('').json()['settings']
+        list_data = [item for item in listing if item['id'] == id][0]
+        assert list_data['created'] == data['created']
+        assert list_data['last_modified'] == data['last_modified']
+
 
     def test_patch_wrong_id(self):
         with assert_http_error(404):

--- a/jupyterlab_server/tests/test_workspaces_api.py
+++ b/jupyterlab_server/tests/test_workspaces_api.py
@@ -2,6 +2,7 @@
 import json
 import os
 import shutil
+from datetime import datetime
 
 from jupyterlab_server.tests.utils import LabTestBase, APITester
 from notebook.tests.launchnotebook import assert_http_error
@@ -47,13 +48,36 @@ class WorkspacesAPITest(LabTestBase):
 
     def test_get(self):
         id = 'foo'
-        assert self.workspaces_api.get(id).json()['metadata']['id'] == id
+        metadata = self.workspaces_api.get(id).json()['metadata']
+        assert metadata['id'] == id
+        assert (
+            datetime.fromisoformat(metadata['created']) <=
+            datetime.fromisoformat(metadata['last_modified'])
+        )
+
+    def test_get_non_existant(self):
+        id = 'baz'
+        ws = self.workspaces_api.get(id).json()
+        assert 'created' not in ws['metadata']
+        assert 'last_modified' not in ws['metadata']
 
     def test_listing(self):
         # ID fields are from workspaces/*.jupyterlab-workspace
         listing = set(['foo', 'f/o/o/'])
         output = set(self.workspaces_api.get().json()['workspaces']['ids'])
         assert output == listing
+
+    def test_listing_dates(self):
+        values = self.workspaces_api.get().json()['workspaces']['values']
+        times = sum(
+            [
+                [ws['metadata'].get('last_modified'), ws['metadata'].get('created')]
+                for ws in values
+            ],
+            []
+        )
+        assert None not in times
+        [datetime.fromisoformat(t) for t in times]
 
     def test_put(self):
         id = 'foo'

--- a/jupyterlab_server/tests/test_workspaces_api.py
+++ b/jupyterlab_server/tests/test_workspaces_api.py
@@ -2,7 +2,7 @@
 import json
 import os
 import shutil
-from datetime import datetime
+from strict_rfc3339 import rfc3339_to_timestamp
 
 from jupyterlab_server.tests.utils import LabTestBase, APITester
 from notebook.tests.launchnotebook import assert_http_error
@@ -51,8 +51,8 @@ class WorkspacesAPITest(LabTestBase):
         metadata = self.workspaces_api.get(id).json()['metadata']
         assert metadata['id'] == id
         assert (
-            datetime.fromisoformat(metadata['created']) <=
-            datetime.fromisoformat(metadata['last_modified'])
+            rfc3339_to_timestamp(metadata['created']) <=
+            rfc3339_to_timestamp(metadata['last_modified'])
         )
 
     def test_get_non_existant(self):
@@ -77,7 +77,7 @@ class WorkspacesAPITest(LabTestBase):
             []
         )
         assert None not in times
-        [datetime.fromisoformat(t) for t in times]
+        [rfc3339_to_timestamp(t) for t in times]
 
     def test_put(self):
         id = 'foo'

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup_args = dict(
 
 if 'setuptools' in sys.modules:
     setup_args['python_requires'] = '>=3.5'
-    setup_args['extras_require'] = {'test': ['pytest', 'requests']}
+    setup_args['extras_require'] = {'test': ['pytest', 'requests', 'strict-rfc3339']}
     setup_args['install_requires'] = [
         'requests',
         'json5',


### PR DESCRIPTION
- fixes #98

Here's a minimal proposal for adding the fields mentioned in #98 to the various API routes for workspaces and settings.

- A workspace may or may not have `metadata.created` or `.last_modified`, but if it appears, should always be an UTC ISO 8601 datetime.
  - since it gets `PUT` back, the user _could_ modify the value, and it would be written to disk, but then overwritten when read back out. seems a little odd, but still okay
- A settings item will _always_ have both `created` and `last_modified`, and can be a UTC ISO 8601 datetime, or `null` in the event that the user hasn't created a settings file (otherwise, there was actually no way to know, as it always returns at least `{}` in `raw`).
  - this value is never written to disk

These both use the newly shimmed `tz` in `server`, but as this doesn't provide a way to _parse_ UTC ISO strings, the tests now also use what `jsonschema` _would_ use, `strict-rfc3339`... and indeed, it, and a few other packages, as runtime dependencies might provide better conformance to the JSON Schema spec. 

Longer term... these handlers would probably benefit from some schema, which would go part of the way towards https://github.com/jupyterlab/jupyterlab/issues/6013.