### PR TITLE
fix file mtime/ctime confusion, restore win3.8, patch event loop

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
           python -m pip list
       - name: Run python tests
         run: |
-          pytest . --tb=long -svv --cov=jupyterlab_server --cov-report term:skip-covered --cov-fail-under 71
+          pytest --cov-fail-under 71
       - name: Upload coverage
         run: |
           codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,6 @@ jobs:
             PLATFORM: 'macos-latest'
           - PYTHON_VERSION: '3.6'
             PLATFORM: 'windows-latest'
-          - PYTHON_VERSION: '3.8'
-            PLATFORM: 'windows-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
           python --version
           python -m pip list
       - name: Run python tests
+        # See `setup.cfg` for full test options
         run: |
           pytest --cov-fail-under 71
       - name: Upload coverage

--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -65,8 +65,8 @@ def _get_user_settings(settings_dir, schema_name, schema):
 
     if os.path.exists(path):
         stat = os.stat(path)
-        last_modified = tz.utcfromtimestamp(stat.st_ctime).isoformat()
-        created = tz.utcfromtimestamp(stat.st_mtime).isoformat()
+        last_modified = tz.utcfromtimestamp(stat.st_mtime).isoformat()
+        created = tz.utcfromtimestamp(stat.st_ctime).isoformat()
         with open(path) as fid:
             try:  # to load and parse the settings file.
                 raw = fid.read() or raw

--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -267,7 +267,7 @@ class SettingsHandler(APIHandler):
 
         if error:
             overrides_warning = 'Failed loading overrides: %s'
-            self.log.warn(overrides_warning % str(error))
+            self.log.warning(overrides_warning % str(error))
 
     @web.authenticated
     def get(self, schema_name=""):
@@ -280,7 +280,7 @@ class SettingsHandler(APIHandler):
         )
 
         if warnings:
-            self.log.warn('\n'.join(warnings))
+            self.log.warning('\n'.join(warnings))
 
         return self.finish(json.dumps(result))
 

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -7,6 +7,9 @@ from strict_rfc3339 import rfc3339_to_timestamp
 from jupyterlab_server.tests.utils import LabTestBase, APITester
 from ..servertest import assert_http_error
 
+from .utils import maybe_patch_ioloop
+
+maybe_patch_ioloop()
 
 class SettingsAPI(APITester):
     """Wrapper for settings REST API requests"""

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -86,10 +86,16 @@ class SettingsAPITest(LabTestBase):
 
         assert self.settings_api.put(id, dict()).status_code == 204
         data = self.settings_api.get(id).json()
-        assert (
-            rfc3339_to_timestamp(data['created']) <=
-            rfc3339_to_timestamp(data['last_modified'])
-        ), data
+        first_created = rfc3339_to_timestamp(data['created']), data
+        first_modified = rfc3339_to_timestamp(data['last_modified']), data
+
+        assert self.settings_api.put(id, dict()).status_code == 204
+        data = self.settings_api.get(id).json()
+        second_created = rfc3339_to_timestamp(data['created']), data
+        second_modified = rfc3339_to_timestamp(data['last_modified']), data
+
+        assert first_created <= second_created
+        assert first_modified < second_modified
 
         listing = self.settings_api.get('').json()['settings']
         list_data = [item for item in listing if item['id'] == id][0]

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -86,13 +86,13 @@ class SettingsAPITest(LabTestBase):
 
         assert self.settings_api.put(id, dict()).status_code == 204
         data = self.settings_api.get(id).json()
-        first_created = rfc3339_to_timestamp(data['created']), data
-        first_modified = rfc3339_to_timestamp(data['last_modified']), data
+        first_created = rfc3339_to_timestamp(data['created'])
+        first_modified = rfc3339_to_timestamp(data['last_modified'])
 
         assert self.settings_api.put(id, dict()).status_code == 204
         data = self.settings_api.get(id).json()
-        second_created = rfc3339_to_timestamp(data['created']), data
-        second_modified = rfc3339_to_timestamp(data['last_modified']), data
+        second_created = rfc3339_to_timestamp(data['created'])
+        second_modified = rfc3339_to_timestamp(data['last_modified'])
 
         assert first_created <= second_created
         assert first_modified < second_modified

--- a/jupyterlab_server/tests/test_translation_api.py
+++ b/jupyterlab_server/tests/test_translation_api.py
@@ -17,6 +17,10 @@ from ..translation_utils import (_get_installed_language_pack_locales,
                                  is_valid_locale, merge_locale_data,
                                  run_process_and_parse)
 
+from .utils import maybe_patch_ioloop
+
+maybe_patch_ioloop()
+
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
 

--- a/jupyterlab_server/tests/test_workspaces_api.py
+++ b/jupyterlab_server/tests/test_workspaces_api.py
@@ -4,11 +4,14 @@ import json
 import os
 import shutil
 
-import pytest
 from strict_rfc3339 import rfc3339_to_timestamp
 
 from jupyterlab_server.tests.utils import LabTestBase, APITester
 from notebook.tests.launchnotebook import assert_http_error
+
+from .utils import maybe_patch_ioloop
+
+maybe_patch_ioloop()
 
 
 class WorkspacesAPI(APITester):
@@ -49,7 +52,6 @@ class WorkspacesAPITest(LabTestBase):
         assert self.workspaces_api.put(copy, data).status_code == 204
         assert self.workspaces_api.delete(copy).status_code == 204
 
-    @pytest.mark.skipif(os.name == "nt", reason="Temporal failure on windows")
     def test_get(self):
         id = 'foo'
         metadata = self.workspaces_api.get(id).json()['metadata']

--- a/jupyterlab_server/tests/test_workspaces_api.py
+++ b/jupyterlab_server/tests/test_workspaces_api.py
@@ -56,10 +56,8 @@ class WorkspacesAPITest(LabTestBase):
         id = 'foo'
         metadata = self.workspaces_api.get(id).json()['metadata']
         assert metadata['id'] == id
-        assert (
-            rfc3339_to_timestamp(metadata['created']) <=
-            rfc3339_to_timestamp(metadata['last_modified'])
-        )
+        assert rfc3339_to_timestamp(metadata['created'])
+        assert rfc3339_to_timestamp(metadata['last_modified'])
 
     def test_get_non_existant(self):
         id = 'baz'
@@ -89,6 +87,17 @@ class WorkspacesAPITest(LabTestBase):
         id = 'foo'
         data = self.workspaces_api.get(id).json()
         assert self.workspaces_api.put(id, data).status_code == 204
+        first_metadata = self.workspaces_api.get(id).json()["metadata"]
+        first_created = rfc3339_to_timestamp(first_metadata['created'])
+        first_modified = rfc3339_to_timestamp(first_metadata['last_modified'])
+
+        assert self.workspaces_api.put(id, data).status_code == 204
+        second_metadata = self.workspaces_api.get(id).json()["metadata"]
+        second_created = rfc3339_to_timestamp(second_metadata['created'])
+        second_modified = rfc3339_to_timestamp(second_metadata['last_modified'])
+
+        assert first_created <= second_created
+        assert first_modified < second_modified
 
     def test_bad_put(self):
         orig = 'foo'

--- a/jupyterlab_server/workspaces_handler.py
+++ b/jupyterlab_server/workspaces_handler.py
@@ -53,8 +53,8 @@ def _load_with_file_times(workspace_path):
     with open(workspace_path) as fid:
         workspace = json.load(fid)
         workspace["metadata"].update(
-            last_modified=tz.utcfromtimestamp(stat.st_ctime).isoformat(),
-            created=tz.utcfromtimestamp(stat.st_mtime).isoformat()
+            last_modified=tz.utcfromtimestamp(stat.st_mtime).isoformat(),
+            created=tz.utcfromtimestamp(stat.st_ctime).isoformat()
         )
     return workspace
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,15 @@
 [metadata]
 license_file = LICENSE
+
+[tool:pytest]
+addopts =
+    --pyargs jupyterlab_server
+    --tb=long
+    -svv
+    --cov jupyterlab_server
+    --cov-report term-missing
+    --cov-report term:skip-covered
+
+filterwarnings =
+    ignore::DeprecationWarning:notebook
+    ignore::DeprecationWarning:traitlets


### PR DESCRIPTION
- extracted from #103
- [x] fixes #106 by swapping the ctime and mtime (whoops)
- [x] adds windows vs python 3.8 test excursion and event loop hack
- [x] fixes `warn` warning
- [x] add tests stuff to `setup.cfg`
  - [x] filter known, unavoidable warnings from notebook, zmq, traitlets
  - [x] moves test args from workflow to `setup.cfg`