### PR TITLE
Ensure JupyterLab on Server supports base_url

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -282,8 +282,7 @@ def add_handlers(handlers, app):
         setattr(app, name, value)
 
     url_pattern = MASTER_URL_PATTERN.format(app.app_url.replace('/', ''))
-    lab_path = ujoin(app.settings.get('base_url'), url_pattern)
-    handlers.append((lab_path, LabHandler, {'lab_config': app}))
+    handlers.append((url_pattern, LabHandler, {'lab_config': app}))
 
     # Cache all or none of the files depending on the `cache_files` setting.
     no_cache_paths = [] if app.cache_files else ['/']

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ if 'setuptools' in sys.modules:
         'jsonschema>=3.0.1',
         'packaging',
         'requests',
-        'jupyter_server~=1.0.0rc5',
+        'jupyter_server~=1.0.0rc7',
     ],
     setup_args['entry_points'] = {
         'pytest11': [


### PR DESCRIPTION
This aims to support `base_url` starting with `jupyter --dev --ServerApp.base_url=/foo` using https://github.com/jupyter/jupyter_server/pull/285

Without this PR, http://localhost:8888/foo/lab returns 404

With this PR, the index page is returned with 

```html
<!doctype html>
<html lang="en">
<head>
  <meta charset="utf-8">
  <title>JupyterLab</title>
  <meta name="viewport" content="width=device-width, initial-scale=1">
  
  <script id="jupyter-config-data" type="application/json">
    {"appName": "JupyterLab", "appNamespace": "lab", "appSettingsDir": "/Users/datalayer/datalayer/repos/jupyterlab/dev_mode/settings", "appUrl": "/lab", "appVersion": "3.0.0a14", "baseUrl": "/foo/", "buildAvailable": false, "buildCheck": false, "cacheFiles": false, "devMode": true, "dynamic_extensions": [], "extraLabextensionsPath": [], "fullAppUrl": "/foo/lab", "fullLabextensionsUrl": "/foo/lab/extensions", "fullListingsUrl": "/foo/lab/api/listings", "fullMathjaxUrl": "/foo/static/nbclassic/components/MathJax/MathJax.js", "fullSettingsUrl": "/foo/lab/api/settings", "fullStaticUrl": "/foo/static/lab", "fullThemesUrl": "/foo/lab/api/themes", "fullTranslationsApiUrl": "/foo/lab/api/translations", "fullTreeUrl": "/foo/lab/tree", "fullWorkspacesApiUrl": "/foo/lab/api/workspaces", "ignorePlugins": [], "labextensionsPath": [], "labextensionsUrl": "/lab/extensions", "listingsUrl": "/lab/api/listings", "mathjaxConfig": "TeX-AMS-MML_HTMLorMML-full,Safe", "mode": "multiple-document", "notebookVersion": "[1, 0, 0, \"rc7\"]", "schemasDir": "/Users/datalayer/datalayer/repos/jupyterlab/dev_mode/schemas", "serverRoot": "~/notebooks", "settingsUrl": "/lab/api/settings", "staticDir": "/Users/datalayer/datalayer/repos/jupyterlab/dev_mode/static", "staticUrl": "/static/lab", "store_id": 2, "templatesDir": "/Users/datalayer/datalayer/repos/jupyterlab/dev_mode/static", "terminalsAvailable": true, "themesDir": "/Users/datalayer/datalayer/repos/jupyterlab/dev_mode/themes", "themesUrl": "/lab/api/themes", "token": "6385fc6c99bbd48984bc3351edb72b5a575cb5bd7c658e49", "translationsApiUrl": "/lab/api/translations", "treePath": "", "treeUrl": "/lab/tree", "userSettingsDir": "/Users/datalayer/.jupyter/lab/user-settings", "workspace": "default", "workspacesApiUrl": "/lab/api/workspaces", "workspacesDir": "/Users/datalayer/.jupyter/lab/workspaces", "wsUrl": ""}
  </script>

  
  <link rel="icon" type="image/x-icon" href="/foo/static/base/images/favicon.ico" class="idle favicon">
  <link rel="" type="image/x-icon" href="/foo/static/base/images/favicon-busy-1.ico" class="busy favicon">
  

</head>
<body>

<script type="text/javascript">
  /* Remove token from URL. */
  (function () {
    var location = window.location;
    var search = location.search;

    // If there is no query string, bail.
    if (search.length <= 1) {
      return;
    }

    // Rebuild the query string without the `token`.
    var query = '?' + search.slice(1).split('&')
      .filter(function (param) { return param.split('=')[0] !== 'token'; })
      .join('&');

    // Rebuild the URL with the new query string.
    var url = location.origin + location.pathname +
      (query !== '?' ? query : '') + location.hash;

    if (url === location.href) {
      return;
    }

    window.history.replaceState({ }, '', url);
  })();
</script>

<script src="/foo/static/lab/vendors-node_modules_whatwg-fetch_fetch_js.ec8e1babec7a84ecf8fa.js"></script><script src="/foo/static/lab/main.dafeaff40af7dbbe7f08.js"></script></body>
</html>
```

But then both `http://localhost:8888/foo/static/lab/vendors-node_modules_whatwg-fetch_fetch_js.ec8e1babec7a84ecf8fa.js` and `http://localhost:8888/foo/static/lab/main.dafeaff40af7dbbe7f08.js` return 404.

It seems like the static content is not retrieved when `base_url=/foo` is set (static is well retrieved with `base_url=/`)

I am blocked so for... Will sleep on that issue...

cc/ @Zsailer @blink1073
