### PR TITLE
Update minimum python version to 3.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,13 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.5', '3.6', '3.8']
+        PYTHON_VERSION: ['3.6', '3.8']
         PLATFORM: ['ubuntu-latest', 'macos-latest',  'windows-latest']
-        exclude:
-          - PYTHON_VERSION: '3.6'
-            PLATFORM: 'macos-latest'
-          - PYTHON_VERSION: '3.6'
-            PLATFORM: 'windows-latest'
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup_args = dict(
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -39,7 +38,7 @@ setup_args = dict(
 )
 
 if 'setuptools' in sys.modules:
-    setup_args['python_requires'] = '>=3.5'
+    setup_args['python_requires'] = '>=3.6'
     setup_args['extras_require'] = {
         'test': [
             'codecov',


### PR DESCRIPTION
In a few weeks, it will be 5 years since the Python 3.5.0 release (13 Sep 2015), which is the normal EOL period for Python.