### PR TITLE
Cache lab extension assets by default

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -290,7 +290,7 @@ def add_handlers(handlers, extension_app):
     handlers.append(
         (labextensions_url, FileFindHandler, {
             'path': labextensions_path,
-            'no_cache_paths': ['/'], # don't cache anything in labextensions
+            'no_cache_paths': no_cache_paths
         }))
 
     # Handle local settings.


### PR DESCRIPTION
Lab extensions now generate files suitable for caching as of https://github.com/jupyterlab/jupyterlab/pull/8913, so we can turn the cache back on by default.