### PR TITLE
Add schemas to settings list

### DIFF
--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -166,6 +166,7 @@ def _list_settings(schemas_dir, settings_dir, overrides, extension='.json', labe
         # Add the plugin to the list of settings.
         settings[id] = dict(
             id=id,
+            schema=schema,
             version=version,
             **user_settings
         )
@@ -203,6 +204,7 @@ def _list_settings(schemas_dir, settings_dir, overrides, extension='.json', labe
             # Add the plugin to the list of settings.
             dynamic_settings[id] = dict(
                 id=id,
+                schema=schema,
                 version=version,
                 **user_settings
             )

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -53,8 +53,10 @@ async def test_listing(fetch, labserverapp):
     res = r.body.decode()
     response = json.loads(res)
     response_ids = [item['id'] for item in response['settings']]
+    response_schemas = [item['schema'] for item in response['settings']]
     response_versions = [item['version'] for item in response['settings']]
     assert set(response_ids) == set(ids)
+    assert all(response_schemas)
     assert set(response_versions) == set(versions)
     last_modifieds = [item['last_modified'] for item in response['settings']]
     createds = [item['created'] for item in response['settings']]


### PR DESCRIPTION
The `GET` request to settings without a plugin specified should return the full list including schemas.

cf. https://github.com/jupyterlab/jupyterlab_server/issues/113
cf. https://github.com/jupyterlab/jupyterlab/issues/8958