### PR TITLE
Remove out of date LICENSE reference to json_minify

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -25,12 +25,3 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-JSON Minify File License
-========================
-
-The json_minify.py file is from
-https://github.com/getify/JSON.minify/tree/python
-which is licensed under the "MIT" license.  See the json_minify.py file for
-details.


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab_server/issues/134