### PR TITLE
Fix var name typo from prev commit

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -78,7 +78,7 @@ def get_page_config(labextensions_path, app_settings_dir=None, logger=None):
     if app_settings_dir:
         app_page_config = pjoin(app_settings_dir, 'page_config.json')
         if osp.exists(app_page_config):
-            with open(old_page_config) as fid:
+            with open(app_page_config) as fid:
                 data = json.load(fid)
 
             # Convert lists to dicts


### PR DESCRIPTION
#137 cleaned up some code but left in an old var name in one place. This causes lab to fail to build due the var not existing