### PR TITLE
don't patch event loop for tornado 6.1+

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
           architecture: 'x64'
       - name: Install python dependencies
         run: |
-          pip install setuptools pip --upgrade --user
+          pip install setuptools pip wheel --upgrade --user
       - name: Install project dependencies
         run: |
           pip install -v -e ".[test]"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   linux:
     name: ${{ matrix.PLATFORM }} py${{ matrix.PYTHON_VERSION }}
-    runs-on: ${{ matrix.PLATFORM }}
+    runs-on: ${{ matrix.PLATFORM }}-latest
     env:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
@@ -20,8 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.6', '3.8']
-        PLATFORM: ['ubuntu-latest', 'macos-latest',  'windows-latest']
+        PYTHON_VERSION: ['3.6', '3.9', 'pypy3']
+        PLATFORM: ['ubuntu', 'macos',  'windows']
+        exclude:
+        - PLATFORM: windows
+          PYTHON_VERSION: pypy3
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -38,11 +41,14 @@ jobs:
       - name: Install python dependencies
         run: |
           pip install setuptools pip --upgrade --user
+      - name: Install project dependencies
+        run: |
           pip install -v -e ".[test]"
       - name: Show python environment
         run: |
           python --version
-          python -m pip list
+          python -m pip freeze
+          python -m pip check
       - name: Run python tests
         # See `setup.cfg` for full test options
         run: |

--- a/jupyterlab_server/tests/utils.py
+++ b/jupyterlab_server/tests/utils.py
@@ -20,7 +20,7 @@ with open(
 def maybe_patch_ioloop():
     """ a windows 3.8+ patch for the asyncio loop
     """
-    if sys.platform.startswith("win"):
+    if sys.platform.startswith("win") and tornado.version_info < (6, 1):
         if sys.version_info >= (3, 8):
             import asyncio
             try:


### PR DESCRIPTION
tornado 6.1 works with the default event loops on all platforms now. I've been working on rooting it out of other repos, still a couple more to do.

As "the future," and having an imminent major version bump, the `jupyter_server` PR _requires_ tornado 6.1
- https://github.com/jupyter-server/jupyter_server/pull/339

As this package is already widely deployed, this uses the "just check the tornado version" approach:
- https://github.com/jupyter/notebook/pull/5907
- https://github.com/ipython/ipykernel/pull/564

Would happily do that, here, if we don't mind pining to the "bleeding edge" tornado, and remove some cruft.