### PR TITLE
Update jupyter_server requirement to 1.* instead of 1.1.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if 'setuptools' in sys.modules:
         'jsonschema>=3.0.1',
         'packaging',
         'requests',
-        'jupyter_server~=1.1.0',
+        'jupyter_server~=1.1',
     ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update jupyter_server requirement to 1.* instead of 1.1.*

Presumably 1.2 will not be backwards compatible...