### PR TITLE
Add URL and description for federated extension data

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -25,7 +25,7 @@ from .server import url_path_join as ujoin
 DEFAULT_TEMPLATE_PATH = osp.join(osp.dirname(__file__), 'templates')
 
 
-def _get_url(data):
+def get_package_url(data):
     """Get the url from the extension data
     """
     # homepage, repository  are optional
@@ -53,7 +53,7 @@ def get_federated_extensions(labextensions_path):
                     name=pkgdata['name'],
                     version=pkgdata['version'],
                     description=pkgdata.get('description', ''),
-                    url=_get_url(pkgdata),
+                    url=get_package_url(pkgdata),
                     ext_dir=ext_dir,
                     ext_path=osp.dirname(ext_path),
                     is_local=False,

--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -25,6 +25,19 @@ from .server import url_path_join as ujoin
 DEFAULT_TEMPLATE_PATH = osp.join(osp.dirname(__file__), 'templates')
 
 
+def _get_url(data):
+    """Get the url from the extension data
+    """
+    # homepage, repository  are optional
+    if 'homepage' in data:
+        url = data['homepage']
+    elif 'repository' in data and isinstance(data['repository'], dict):
+        url = data['repository'].get('url', '')
+    else:
+        url = ''
+    return url
+
+
 def get_federated_extensions(labextensions_path):
     """Get the metadata about federated extensions
     """
@@ -39,6 +52,8 @@ def get_federated_extensions(labextensions_path):
                 data = dict(
                     name=pkgdata['name'],
                     version=pkgdata['version'],
+                    description=pkgdata.get('description', ''),
+                    url=_get_url(pkgdata),
                     ext_dir=ext_dir,
                     ext_path=osp.dirname(ext_path),
                     is_local=False,


### PR DESCRIPTION
https://github.com/jupyterlab/jupyterlab/pull/9702 was just merged to expose the federated extension URL in the frontend, but I think that the actual URL is never set and that's why my attempt to test that PR on binder failed.

The URL (and description) is getting passed along the way here:

https://github.com/jupyterlab/jupyterlab/blob/6f4ba75604c9e6291b669119e9e42702458b6688/jupyterlab/handlers/extension_manager_handler.py#L103-L112

So it should be enough to make it work. The code for `_get_url` is extracted from:

https://github.com/jupyterlab/jupyterlab/blob/136d2ec216ebfc429a696e6ee75fee5f8ead73e2/jupyterlab/commands.py#L1404-L1410

and thinking about it now it should not be private, but exposed so that jupyterlab can re-use the same `get_url` for source extensions in the future. I will wait for feedback though.