### PR TITLE
Reduce path length of installed package

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,13 +1,6 @@
 name: Tests
 
-on:
-  push:
-    branches:
-      - master
-
-  pull_request:
-    branches:
-      - "*"
+on: [push, pull_request]
 
 jobs:
   linux:
@@ -40,10 +33,10 @@ jobs:
           architecture: 'x64'
       - name: Install python dependencies
         run: |
-          pip install setuptools pip wheel --upgrade --user
+          pip install setuptools pip wheel --upgrade --user --cache-dir ~/.cache/pip
       - name: Install project dependencies
         run: |
-          pip install -v -e ".[test]"
+          pip install -v -e ".[test]" --cache-dir ~/.cache/pip
       - name: Show python environment
         run: |
           python --version
@@ -56,3 +49,11 @@ jobs:
       - name: Upload coverage
         run: |
           codecov
+      - name: Install and Test SDist
+        if: ${{ runner.os != 'Windows' }}
+        run: |
+          pip uninstall -y jupyterlab_server
+          python setup.py sdist
+          cd dist
+          pip install *.tar.gz
+          pytest --pyargs jupyterlab_server

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,9 @@ include setupbase.py
 include jupyterlab_server/templates/*.html
 recursive-include jupyterlab_server/tests *.json *.json.orig *.jupyterlab-workspace
 
+# prune translation test data to avoid long path limits on Windows
+prune jupyterlab_server/tests/translations
+
 # Patterns to exclude from any directory
 global-exclude *~
 global-exclude *.pyc

--- a/jupyterlab_server/tests/test_translation_api.py
+++ b/jupyterlab_server/tests/test_translation_api.py
@@ -23,6 +23,9 @@ maybe_patch_ioloop()
 # Constants
 HERE = os.path.abspath(os.path.dirname(__file__))
 
+if not os.path.exists(os.path.join(HERE, 'translations')):
+    pytest.skip("skipping translation tests", allow_module_level=True)
+
 
 def setup_module(module):
     """ setup any state specific to the execution of this module."""


### PR DESCRIPTION
Fixes jupyterlab/jupyterlab_server#151 by removing the example translation packages from the distributed package. Adds a CI test against the installed tarball to make sure the test suite still passes in the installed package.