### PR TITLE
Alleviate invalid locale issue by only setting it if language pack exists

### DIFF
--- a/jupyterlab_server/translations_handler.py
+++ b/jupyterlab_server/translations_handler.py
@@ -82,7 +82,8 @@ class TranslationsHandler(APIHandler):
                         message = "Language pack '{}' not valid!".format(locale)
                 else:
                     # only change locale if the language pack is installed and valid
-                    translator.set_locale(locale)
+                    if is_valid_locale(locale):
+                        translator.set_locale(locale)
         except Exception:
             message = traceback.format_exc()
 

--- a/jupyterlab_server/translations_handler.py
+++ b/jupyterlab_server/translations_handler.py
@@ -74,13 +74,15 @@ class TranslationsHandler(APIHandler):
                 data, message = get_language_packs(
                     display_locale=get_current_locale(self.lab_config))
             else:
-                translator.set_locale(locale)
                 data, message = get_language_pack(locale)
                 if data == {} and message == "":
                     if is_valid_locale(locale):
                         message = "Language pack '{}' not installed!".format(locale)
                     else:
                         message = "Language pack '{}' not valid!".format(locale)
+                else:
+                    # only change locale if the language pack is installed and valid
+                    translator.set_locale(locale)
         except Exception:
             message = traceback.format_exc()
 


### PR DESCRIPTION
As discussed in https://github.com/jupyterlab/jupyterlab/issues/9672 jupyterlab_server 2.1 broke workflows of some users and broke jupyter server extensions that have any dependency that requires locale to be correct, because it sets wrong locale. By wrong I mean locale that does not exist and which crashes other programs, e.g. a jupyter-server extension (not jupyterlab-server) that subprocesses a program with Click CLI:

```
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment. Consult https://click.palletsprojects.com/python3/ for mitigation steps.

This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8

Click discovered that you exported a UTF-8 locale but the locale system could not pick up from it because it does not exist. The exported locale is 'en.UTF-8' but it is not supported
```

Or leads them to output warning messages about invalid locale (e.g. `R`):

```
1: Setting LC_CTYPE failed, using "C" 
2: Setting LC_COLLATE failed, using "C" 
3: Setting LC_TIME failed, using "C" 
4: Setting LC_MESSAGES failed, using "C" 
5: Setting LC_MONETARY failed, using "C" 
6: Setting LC_PAPER failed, using "C" 
7: Setting LC_MEASUREMENT failed, using "C" 
```

Which has dire downstream consequences:

> This happens also in R, and in R it has the consequence that the locale is set to "C" (Sys.getlocale("LC_CTYPE")), localeToCharset() returns "ASCII" and all printed output in UTF-8 is decoded to ASCII text representation. If I use jupyter notebook instead, LANG does not get changed and R UTF-8 output is displayed correctly (https://github.com/jupyterlab/jupyterlab/issues/9672#issue-793838482)

This PR is not guaranteed to fix the issue of wrong locale by itself, but hopefully eliminates some unwanted changes of locale, this is setting it when the language pack is not installed and when babel thinks that it is not valid.