### PR TITLE
Switch to entrypoints package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ docs/source/changelog.md
 
 # generated cli docs
 docs/source/api/app-config.rst
+
+.vscode/

--- a/jupyterlab_server/tests/test_translation_api.py
+++ b/jupyterlab_server/tests/test_translation_api.py
@@ -14,7 +14,7 @@ from ..translation_utils import (_get_installed_language_pack_locales,
                                  get_installed_packages_locale,
                                  get_language_pack, get_language_packs,
                                  is_valid_locale, merge_locale_data,
-                                 run_process_and_parse, translator)
+                                 translator)
 
 from .utils import maybe_patch_ioloop
 from .utils import validate_request
@@ -130,31 +130,13 @@ async def test_backend_locale_extension(jp_fetch):
 
 # --- Utils testing
 # ------------------------------------------------------------------------
-def test_get_installed_language_pack_locales_fails():
-    # This should not be able to find entry points, since it needs to be
-    # ran in a subprocess
-    data, message = _get_installed_language_pack_locales()
-    assert "es_CO" not in data
-    assert message == ""
-
 def test_get_installed_language_pack_locales_passes():
-    utils_file = os.path.join(os.path.dirname(HERE), "translation_utils.py")
-    cmd = [sys.executable, utils_file, "_get_installed_language_pack_locales"]
-    data, message = run_process_and_parse(cmd)
+    data, message = _get_installed_language_pack_locales()
     assert "es_CO" in data
     assert message == ""
 
-def test_get_installed_package_locales_fails():
-    # This should not be able to find entry points, since it needs to be
-    # ran in a subprocess
-    data, message = _get_installed_package_locales()
-    assert "jupyterlab_some_package" not in data
-    assert message == ""
-
 def test_get_installed_package_locales():
-    utils_file = os.path.join(os.path.dirname(HERE), "translation_utils.py")
-    cmd = [sys.executable, utils_file, "_get_installed_package_locales"]
-    data, message = run_process_and_parse(cmd)
+    data, message = _get_installed_package_locales()
     assert "jupyterlab_some_package" in data
     assert os.path.isdir(data["jupyterlab_some_package"])
     assert message == ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     babel
-    entrypoints >=0.2.2
+    entrypoints>=0.2.2
     jinja2>=2.10
     json5
     jsonschema>=3.0.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     babel
+    entrypoints >=0.2.2
     jinja2>=2.10
     json5
     jsonschema>=3.0.1


### PR DESCRIPTION
Use entrypoints package to list translation entry points

Advantages:
- It is already a dependency (from the notebook server)
- it is more efficient than pkgresources
- it lists the entry points from the current sys.path => no need to run the listing in a subprocess