### PR TITLE
Merge overrides settings if values are dicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ github_url: 'https://github.com/jupyterlab/jupyterlab_server/blob/master/CHANGEL
 
 ## 2.1.5
 
-* Fix/cp949 encoding error [#158](https://github.com/jupyterlab/jupyterlab_server/pull/158) ([@takavfx](https://github.com/takavfx))
+* Fix/cp949 encoding error [#158](https://github.com/jupyterlab/jupyterlab_server/pull/158) ([@k-takanori](https://github.com/k-takanori))
 
 ## 2.1.4
 

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
 - python=3.8
-- sphinx>=1.8
+- sphinx<4.0
 - sphinx-copybutton
 - pip
 - myst-parser

--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -217,11 +217,10 @@ def _override(schema_name, schema, overrides):
         defaults = overrides[schema_name]
         for key in defaults:
             if key in schema['properties']:
-                # schema['properties'][key]['default'] = defaults[key]
                 new_defaults = schema['properties'][key]['default']
+                # If values for defaults are dicts do a recursive update
                 if isinstance(new_defaults, dict):
-                    new_defaults = new_defaults.copy()
-                    new_defaults.update(defaults[key])
+                    recursive_update(new_defaults.copy(), defaults[key])
                 else:
                     new_defaults = defaults[key]
 

--- a/jupyterlab_server/tests/app-settings/overrides.json
+++ b/jupyterlab_server/tests/app-settings/overrides.json
@@ -1,6 +1,9 @@
 {
   "@jupyterlab/apputils-extension:themes": {
-    "theme": "JupyterLab Dark"
+    "theme": "JupyterLab Dark",
+    "codeCellConfig": {
+      "lineNumbers": false
+   }
   },
   "@jupyterlab/unicode-extension:plugin": {
     "comment": "Here are some languages with unicode in their names: id: Bahasa Indonesia, ms: Bahasa Melayu, bs: Bosanski, ca: Català, cs: Čeština, da: Dansk, de: Deutsch, et: Eesti, en: English, es: Español, fil: Filipino, fr: Français, it: Italiano, hu: Magyar, nl: Nederlands, no: Norsk, pl: Polski, pt-br: Português (Brasil), pt: Português (Portugal), ro: Română, fi: Suomi, sv: Svenska, vi: Tiếng Việt, tr: Türkçe, el: Ελληνικά, ru: Русский, sr: Српски, uk: Українська, he: עברית, ar: العربية, th: ไทย, ko: 한국어, ja: 日本語, zh: 中文（中国）, zh-tw: 中文（台灣）"

--- a/jupyterlab_server/tests/schemas/@jupyterlab/apputils-extension/themes.json
+++ b/jupyterlab_server/tests/schemas/@jupyterlab/apputils-extension/themes.json
@@ -4,6 +4,28 @@
   "properties": {
     "theme": {
       "type": "string", "title": "Selected Theme", "default": "JupyterLab Light"
+    },
+    "codeCellConfig": {
+      "title": "Code Cell Configuration",
+      "description": "The configuration for all code cells.",
+      "$ref": "#/definitions/editorConfig",
+      "default": {
+        "autoClosingBrackets": true,
+        "cursorBlinkRate": 530,
+        "fontFamily": null,
+        "fontSize": null,
+        "lineHeight": null,
+        "lineNumbers": false,
+        "lineWrap": "off",
+        "matchBrackets": true,
+        "readOnly": false,
+        "insertSpaces": true,
+        "tabSize": 4,
+        "wordWrapColumn": 80,
+        "rulers": [],
+        "codeFolding": false,
+        "lineWiseCopyCut": true
+      }
     }
   },
   "type": "object"

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -13,6 +13,21 @@ from .utils import maybe_patch_ioloop, big_unicode_string
 from .utils import validate_request
 
 
+async def test_get_settings_overrides_dicts(jp_fetch, labserverapp):
+    # Check that values that are dictionaries in overrides.json are
+    # merged with the schema.
+    id = '@jupyterlab/apputils-extension:themes'
+    r = await jp_fetch('lab', 'api', 'settings', id)
+    validate_request(r)
+    res = r.body.decode()
+    data = json.loads(res)
+    assert data['id'] == id
+    schema = data['schema']
+    # Check that overrides.json file is respected.
+    assert schema['properties']['codeCellConfig']['default']["lineNumbers"] is False
+    assert len(schema['properties']['codeCellConfig']['default']) == 15
+
+
 async def test_get_settings(jp_fetch, labserverapp):
     id = '@jupyterlab/apputils-extension:themes'
     r = await jp_fetch('lab', 'api', 'settings', id)


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/10010

When using overrides files, if a default value in a schema is a `dict` then it will update the default with the `dict` provided by the overrides file.


With `overrides.json`
```json
{
  "@jupyterlab/notebook-extension:tracker": {
      "codeCellConfig": {
         "lineNumbers": false
      }
  }
}
```

## Before this change

The resulting system default settings would be:

```json5
{
    // Notebook
    // @jupyterlab/notebook-extension:tracker
    // Notebook settings.
    // **************************************

    // Code Cell Configuration
    // The configuration for all code cells.
    "codeCellConfig": {
        "lineNumbers": false,
    },
....
```

## After this change

The resulting system default settings would be:

```json5
{
    // Notebook
    // @jupyterlab/notebook-extension:tracker
    // Notebook settings.
    // **************************************

    // Code Cell Configuration
    // The configuration for all code cells.
    "codeCellConfig": {
        "autoClosingBrackets": true,
        "cursorBlinkRate": 530,
        "fontFamily": null,
        "fontSize": null,
        "lineHeight": null,
        "lineNumbers": false,
        "lineWrap": "off",
        "matchBrackets": true,
        "readOnly": false,
        "insertSpaces": true,
        "tabSize": 4,
        "wordWrapColumn": 80,
        "rulers": [],
        "codeFolding": false,
        "lineWiseCopyCut": true
    },
....
```