### PR TITLE
Automated Changelog Entry for 2.6.1 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ github_url: 'https://github.com/jupyterlab/jupyterlab_server/blob/master/CHANGEL
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2.6.1
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab_server/compare/v2.6.0...52f4cf92adb8b6dc3b350ce324619a231a9003ba))
+
+### Enhancements made
+
+- Merge overrides settings if values are dicts [#188](https://github.com/jupyterlab/jupyterlab_server/pull/188) ([@goanpeca](https://github.com/goanpeca))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab_server/graphs/contributors?from=2021-06-01&to=2021-07-09&type=c))
+
+[@goanpeca](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_server+involves%3Agoanpeca+updated%3A2021-06-01..2021-07-09&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 2.6.0
 
 ([Full Changelog](https://github.com/jupyterlab/jupyterlab_server/compare/v2.5.2...167867d1b49b48735e57106bb13bcc7efd8f2dde))
@@ -23,8 +39,6 @@ github_url: 'https://github.com/jupyterlab/jupyterlab_server/blob/master/CHANGEL
 ([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab_server/graphs/contributors?from=2021-05-17&to=2021-06-01&type=c))
 
 [@blink1073](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_server+involves%3Ablink1073+updated%3A2021-05-17..2021-06-01&type=Issues) | [@bollwyvl](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_server+involves%3Abollwyvl+updated%3A2021-05-17..2021-06-01&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 2.5.1
 


### PR DESCRIPTION
Automated Changelog Entry for 2.6.1 on master

After merging this PR run the "Draft Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab_server  |
| Branch  | master  |
| Version Spec | 2.6.1 |
