### PR TITLE
PR: Add preferred dir option to config

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -84,6 +84,15 @@ class LabHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandl
         page_config.setdefault('ignorePlugins', [])
         page_config.setdefault('serverRoot', server_root)
         page_config['store_id'] = self.application.store_id
+
+        server_root = os.path.normpath(os.path.expanduser(server_root))
+        try:
+            page_config['preferredDir'] = self.serverapp.preferred_dir
+            page_config['preferredPath'] = self.serverapp.preferred_dir.replace(server_root, "")
+        except Exception:
+            page_config['preferredDir'] = server_root
+            page_config['preferredPath'] = '/'
+
         self.application.store_id += 1
 
         mathjax_config = self.settings.get('mathjax_config',


### PR DESCRIPTION
Following on the [discussion of adding a new trait](https://github.com/jupyter-server/jupyter_server/issues/534) `preferred-dir`

And the PR on JServer -> https://github.com/jupyter-server/jupyter_server/pull/549

This PR now exposes that option on the page config. I added both the full url and the relative path to use if found in the frontend which is using it over at https://github.com/jupyterlab/jupyterlab/pull/10667


