### PR TITLE
PR: Update new_defaults dictionary instead of copy

### DIFF
--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -220,7 +220,7 @@ def _override(schema_name, schema, overrides):
                 new_defaults = schema['properties'][key]['default']
                 # If values for defaults are dicts do a recursive update
                 if isinstance(new_defaults, dict):
-                    recursive_update(new_defaults.copy(), defaults[key])
+                    recursive_update(new_defaults, defaults[key])
                 else:
                     new_defaults = defaults[key]
 

--- a/jupyterlab_server/tests/app-settings/overrides.json
+++ b/jupyterlab_server/tests/app-settings/overrides.json
@@ -2,7 +2,7 @@
   "@jupyterlab/apputils-extension:themes": {
     "theme": "JupyterLab Dark",
     "codeCellConfig": {
-      "lineNumbers": false
+      "lineNumbers": true
    }
   },
   "@jupyterlab/unicode-extension:plugin": {

--- a/jupyterlab_server/tests/test_settings_api.py
+++ b/jupyterlab_server/tests/test_settings_api.py
@@ -24,7 +24,7 @@ async def test_get_settings_overrides_dicts(jp_fetch, labserverapp):
     assert data['id'] == id
     schema = data['schema']
     # Check that overrides.json file is respected.
-    assert schema['properties']['codeCellConfig']['default']["lineNumbers"] is False
+    assert schema['properties']['codeCellConfig']['default']["lineNumbers"] is True
     assert len(schema['properties']['codeCellConfig']['default']) == 15
 
 


### PR DESCRIPTION
Fixes a bug introduced on https://github.com/jupyterlab/jupyterlab_server/pull/188 which broke the overrides mechanism for defaults that ara dictionaries 😞 

