### PR TITLE
TST: support openapi-core 0.14 SpecPath

### DIFF
--- a/jupyterlab_server/tests/utils.py
+++ b/jupyterlab_server/tests/utils.py
@@ -10,10 +10,9 @@ from urllib.parse import parse_qs, urlparse, urljoin
 from openapi_core.validation.request.datatypes import (
     RequestParameters, OpenAPIRequest
 )
-from openapi_core import create_spec
-from openapi_core.exceptions import OpenAPIError
-from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response.datatypes import OpenAPIResponse
+from openapi_core import create_spec
+from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response.validators import ResponseValidator
 import requests
 from ruamel.yaml import YAML
@@ -45,13 +44,7 @@ def wrap_request(request, spec):
     # work around lack of support for path parameters which can contain slashes
     # https://github.com/OAI/OpenAPI-Specification/issues/892
     url = None
-    try:
-       # with openapi-core >= 0.14 spec is a SpecPath object
-       specpaths = spec['paths']
-    except OpenAPIError:
-       # openapi-core < 0.14 spec is a Spec object
-       specpaths = spec.paths
-    for path in specpaths:
+    for path in spec['paths']:
         if url:
             continue
         has_arg = '{' in path

--- a/jupyterlab_server/tests/utils.py
+++ b/jupyterlab_server/tests/utils.py
@@ -10,9 +10,10 @@ from urllib.parse import parse_qs, urlparse, urljoin
 from openapi_core.validation.request.datatypes import (
     RequestParameters, OpenAPIRequest
 )
-from openapi_core.validation.response.datatypes import OpenAPIResponse
 from openapi_core import create_spec
+from openapi_core.exceptions import OpenAPIError
 from openapi_core.validation.request.validators import RequestValidator
+from openapi_core.validation.response.datatypes import OpenAPIResponse
 from openapi_core.validation.response.validators import ResponseValidator
 import requests
 from ruamel.yaml import YAML
@@ -44,7 +45,13 @@ def wrap_request(request, spec):
     # work around lack of support for path parameters which can contain slashes
     # https://github.com/OAI/OpenAPI-Specification/issues/892
     url = None
-    for path in spec.paths:
+    try:
+       # with openapi-core >= 0.14 spec is a SpecPath object
+       specpaths = spec['paths']
+    except OpenAPIError:
+       # openapi-core < 0.14 spec is a Spec object
+       specpaths = spec.paths
+    for path in specpaths:
         if url:
             continue
         has_arg = '{' in path

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 
 
 [options.extras_require]
-test = codecov; ipykernel; pytest>=5.3.2; pytest-cov; jupyter_server[test]; openapi_core~=0.13.8; pytest-console-scripts; strict-rfc3339; ruamel.yaml; wheel
+test = codecov; ipykernel; pytest>=5.3.2; pytest-cov; jupyter_server[test]; openapi_core>=0.13.8; pytest-console-scripts; strict-rfc3339; ruamel.yaml; wheel
 
 [options.packages.find]
 exclude = ['docs*']

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
 
 
 [options.extras_require]
-test = codecov; ipykernel; pytest>=5.3.2; pytest-cov; jupyter_server[test]; openapi_core>=0.13.8; pytest-console-scripts; strict-rfc3339; ruamel.yaml; wheel
+test = codecov; ipykernel; pytest>=5.3.2; pytest-cov; jupyter_server[test]; openapi_core~=0.14.0; pytest-console-scripts; strict-rfc3339; ruamel.yaml; wheel
 
 [options.packages.find]
 exclude = ['docs*']


### PR DESCRIPTION
openapi-core had a severe API change: create_spec now returns a SpecPath instead of Spec.

In order to not have to pin to < 0.14 in openSUSE Tumleweed, here is a patch dealing with both APIs.

`spec['paths']` throws `openapi_core.schema.paths.exceptions.InvalidPath` in openapi-core 0.13.8, which is not importable in 0.14. The `OpenAPIError` is a common exception for the two versions.

Another possibility would be to just require ~=0.14.0 and always get a `SpecPath`.