### PR TITLE
Fix reset user settings if validation failed

### DIFF
--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -100,6 +100,7 @@ def _get_user_settings(settings_dir, schema_name, schema):
         except ValidationError as e:
             warning = validation_warning % (schema_name, str(e))
             raw = '{}'
+            settings = {}
 
     return dict(
         raw=raw,


### PR DESCRIPTION
If user settings are not valid, `raw` is set to an empty object but `settings` is kept unchanged.

This makes `settings` equivalent to `raw` in case of validation error.