### PR TITLE
Do not overwrite capitalization of region names

### DIFF
--- a/jupyterlab_server/tests/test_translation_api.py
+++ b/jupyterlab_server/tests/test_translation_api.py
@@ -219,6 +219,7 @@ def test_get_display_name_valid():
     assert get_display_name("en", "fr") == "Anglais"
     assert get_display_name("es", "en") == "Spanish"
     assert get_display_name("fr", "en") == "French"
+    assert get_display_name("pl_pl", "en") == "Polish (Poland)"
 
 
 def test_get_display_name_invalid():

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -164,7 +164,10 @@ def get_display_name(locale: str, display_locale: str = DEFAULT_LOCALE) -> str:
         display_locale if is_valid_locale(display_locale) else DEFAULT_LOCALE
     )
     loc = babel.Locale.parse(locale)
-    return loc.get_display_name(display_locale).capitalize()
+    display_name = loc.get_display_name(display_locale)
+    if display_name:
+        display_name = display_name[0].upper() + display_name[1:]
+    return display_name
 
 
 def merge_locale_data(language_pack_locale_data, package_locale_data):


### PR DESCRIPTION
Previously the display name would return "Polish (poland)" even though the underlying babel correctly capitalizes Poland.

Fixes https://github.com/jupyterlab/jupyterlab/issues/10736#issuecomment-903280123.