### PR TITLE
Recommend `pytest --pyargs jupyterlab_server`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,5 +16,5 @@ To create a local test setup run the following commands (inside your virtual env
 git clone https://github.com/jupyterlab/jupyterlab_server.git
 cd jupyterlab_server
 pip install -e .[test]  # install test dependencies
-pytest
+pytest --pyargs jupyterlab_server
 ```


### PR DESCRIPTION
When using just `pytest` as advised in current CONTRIBUTING.md I got a warning:

```
Defining 'pytest_plugins' in a non-top-level conftest is no longer supported:
It affects the entire test suite instead of just below the conftest as expected.
  /home/krassowski/jupyterlab_server/jupyterlab_server/tests/conftest.py
Please move it to a top level conftest file at the rootdir:
  /home/krassowski/jupyterlab_server
For more information, visit:
  https://docs.pytest.org/en/stable/deprecations.html#pytest-plugins-in-non-top-level-conftest-files
```

and the test did not run.