### PR TITLE
Fall back to `DEFAULT_LOCALE` when translation settings schema is invalid in `get_current_locale`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,11 @@ docs/source/changelog.md
 # generated cli docs
 docs/source/api/app-config.rst
 
-.vscode/
+# jetbrains IDE stuff
+*.iml
+.idea/
+
+# ms IDE stuff
+*.code-workspace
+.history
+.vscode

--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -35,7 +35,14 @@ class SettingsHandler(ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, SchemaH
         """Get setting(s)"""
         # Need to be update here as translator locale is not change when a new locale is put
         # from frontend
-        translator.set_locale(self.get_current_locale())
+        try:
+            locale = self.get_current_locale()
+        except web.HTTPError as e:
+            # fallback in case of missing (404) or misshapen (500) translation schema
+            locale = DEFAULT_LOCALE
+            'Failed loading or validating translation settings schema'
+
+        translator.set_locale(locale)
 
         result, warnings = get_settings(
             self.app_settings_dir,


### PR DESCRIPTION
Needed to fix final CI bug for jupyterlab/jupyterlab#10929. Essentially, this PR restores the pre-#205 behavior by which a missing or malformed translation settings schema would result in `get_current_locale` returning `DEFAULT_LOCALE`. This PR also slightly improves said old behavior by producing an informative warning when this happens, instead of being silent like before.

Tested locally, fixes the problem.

pinging @fcollonval, @blink1073