### PR TITLE
Clean unneeded catch

### DIFF
--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -35,13 +35,7 @@ class SettingsHandler(ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, SchemaH
         """Get setting(s)"""
         # Need to be update here as translator locale is not change when a new locale is put
         # from frontend
-        try:
-            locale = self.get_current_locale()
-        except web.HTTPError as e:
-            # fallback in case of missing (404) or misshapen (500) translation schema
-            locale = DEFAULT_LOCALE
-            'Failed loading or validating translation settings schema'
-
+        locale = self.get_current_locale()
         translator.set_locale(locale)
 
         result, warnings = get_settings(


### PR DESCRIPTION
The error is handle in `get_current_locale` directly

Fix #209