### PR TITLE
Fix workspace export without arguments

### DIFF
--- a/jupyterlab_server/workspaces_app.py
+++ b/jupyterlab_server/workspaces_app.py
@@ -11,6 +11,9 @@ from .config import LabConfig
 from .workspaces_handler import WorkspacesManager
 
 
+DEFAULT_WORKSPACE = "default"
+
+
 class WorkspaceListApp(JupyterApp, LabConfig):
     version = __version__
     description = """
@@ -84,7 +87,7 @@ class WorkspaceExportApp(JupyterApp, LabConfig):
             print("Too many arguments were provided for workspace export.")
             self.exit(1)
 
-        raw = self.extra_args[0]
+        raw = DEFAULT_WORKSPACE if not self.extra_args else self.extra_args[0]
         try:
             workspace = self.manager.load(raw)
             print(json.dumps(workspace))

--- a/jupyterlab_server/workspaces_app.py
+++ b/jupyterlab_server/workspaces_app.py
@@ -10,7 +10,8 @@ from ._version import __version__
 from .config import LabConfig
 from .workspaces_handler import WorkspacesManager
 
-
+# Default workspace ID
+#  Needs to match PageConfig.defaultWorkspace define in packages/coreutils/src/pageconfig.ts
 DEFAULT_WORKSPACE = "default"
 
 


### PR DESCRIPTION
Error seen in https://github.com/jupyterlab/jupyterlab/pull/11730

`jupyter lab workspaces export` should return the default workspace. This fixes it.

The default workspace id is hard coded (as it is done in JupyterLab `PageConfig.defaultWorkspace`).