### PR TITLE
Clean up tests and add public openapi_spec

### DIFF
--- a/jupyterlab_server/__init__.py
+++ b/jupyterlab_server/__init__.py
@@ -4,6 +4,7 @@
 from .app import LabServerApp
 from .licenses_app import LicensesApp
 from .handlers import add_handlers, LabHandler, LabConfig
+from .spec import openapi_spec, openapi_spec_dict
 from .translation_utils import translator
 from .workspaces_app import WorkspaceExportApp, WorkspaceImportApp, WorkspaceListApp
 from .workspaces_handler import slugify, WORKSPACE_EXTENSION

--- a/jupyterlab_server/spec.py
+++ b/jupyterlab_server/spec.py
@@ -1,0 +1,11 @@
+import os
+from pathlib import Path
+
+from ruamel.yaml import YAML
+from openapi_core import create_spec
+
+HERE = Path(os.path.dirname(__file__)).resolve()
+path = HERE / 'rest-api.yml'
+yaml = YAML(typ='safe')
+openapi_spec_dict = yaml.load(path.read_text(encoding='utf-8'))
+openapi_spec = create_spec(openapi_spec_dict)

--- a/jupyterlab_server/test_utils.py
+++ b/jupyterlab_server/test_utils.py
@@ -1,22 +1,21 @@
-import errno
 import json
 import os
 import sys
 from contextlib import contextmanager
 from http.cookies import SimpleCookie
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse, urljoin
+from urllib.parse import parse_qs, urlparse
 
 from openapi_core.validation.request.datatypes import (
     RequestParameters, OpenAPIRequest
 )
 from openapi_core.validation.response.datatypes import OpenAPIResponse
-from openapi_core import create_spec
 from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response.validators import ResponseValidator
 import requests
-from ruamel.yaml import YAML
 import tornado
+
+from jupyterlab_server.spec import openapi_spec
 
 
 HERE = Path(os.path.dirname(__file__)).resolve()
@@ -96,18 +95,13 @@ def wrap_response(response):
 
 def validate_request(response):
     """Validate an API request"""
-    path = HERE / 'rest-api.yml'
-    yaml = YAML(typ='safe')
-    spec_dict = yaml.load(path.read_text(encoding='utf-8'))
-    spec = create_spec(spec_dict)
-
-    validator = RequestValidator(spec)
-    request = wrap_request(response.request, spec)
+    validator = RequestValidator(openapi_spec)
+    request = wrap_request(response.request, openapi_spec)
     result = validator.validate(request)
     print(result.errors)
     result.raise_for_errors()
 
-    validator = ResponseValidator(spec)
+    validator = ResponseValidator(openapi_spec)
     response = wrap_response(response)
     result = validator.validate(request, response)
     print(result.errors)

--- a/jupyterlab_server/test_utils.py
+++ b/jupyterlab_server/test_utils.py
@@ -19,10 +19,10 @@ from ruamel.yaml import YAML
 import tornado
 
 
-here = os.path.dirname(__file__)
+HERE = Path(os.path.dirname(__file__)).resolve()
 
 with open(
-    os.path.abspath(os.path.join(here, '..', 'jupyterlab_server', 'test_data', 'app-settings', 'overrides.json')),
+    HERE / 'test_data' / 'app-settings' / 'overrides.json',
     encoding='utf-8'
 ) as fpt:
     big_unicode_string = json.load(fpt)["@jupyterlab/unicode-extension:plugin"]["comment"]
@@ -96,7 +96,7 @@ def wrap_response(response):
 
 def validate_request(response):
     """Validate an API request"""
-    path = (Path(here) / '../jupyterlab_server/rest-api.yml').resolve()
+    path = HERE / 'rest-api.yml'
     yaml = YAML(typ='safe')
     spec_dict = yaml.load(path.read_text(encoding='utf-8'))
     spec = create_spec(spec_dict)

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ test =
     ipykernel
     pytest>=5.3.2
     pytest-cov
-    jupyter_server[test];
+    jupyter_server[test]
     pytest-console-scripts
     strict-rfc3339
     wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,12 +32,23 @@ install_requires =
     jinja2>=3.0.3
     json5
     jsonschema>=3.0.1
+    openapi_core>=0.14.2
     packaging
     requests
+    ruamel.yaml
     jupyter_server~=1.8
 
 [options.extras_require]
-test = codecov; ipykernel; pytest>=5.3.2; pytest-cov; jupyter_server[test]; openapi_core>=0.14.2; pytest-console-scripts; strict-rfc3339; ruamel.yaml; wheel; openapi-spec-validator<0.5
+test =
+    codecov
+    ipykernel
+    pytest>=5.3.2
+    pytest-cov
+    jupyter_server[test];
+    pytest-console-scripts
+    strict-rfc3339
+    wheel
+    openapi-spec-validator<0.5
 
 [options.packages.find]
 exclude =

--- a/tests/test_labapp.py
+++ b/tests/test_labapp.py
@@ -4,7 +4,7 @@
 import pytest
 import tornado
 
-from .utils import expected_http_error
+from jupyterlab_server.test_utils import expected_http_error
 
 
 @pytest.fixture

--- a/tests/test_listings_api.py
+++ b/tests/test_listings_api.py
@@ -1,5 +1,5 @@
 
-from .utils import validate_request
+from jupyterlab_server.test_utils import validate_request
 
 
 async def test_get_listing(jp_fetch, labserverapp):

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -9,9 +9,9 @@ import tornado
 
 from strict_rfc3339 import rfc3339_to_timestamp
 
-from .utils import expected_http_error
-from .utils import maybe_patch_ioloop, big_unicode_string
-from .utils import validate_request
+from jupyterlab_server.test_utils import expected_http_error
+from jupyterlab_server.test_utils import maybe_patch_ioloop, big_unicode_string
+from jupyterlab_server.test_utils import validate_request
 
 
 async def test_get_settings_overrides_dicts(jp_fetch, labserverapp):

--- a/tests/test_themes_api.py
+++ b/tests/test_themes_api.py
@@ -1,5 +1,5 @@
 
-from .utils import validate_request
+from jupyterlab_server.test_utils import validate_request
 
 
 async def test_get_theme(jp_fetch, labserverapp):

--- a/tests/test_translation_api.py
+++ b/tests/test_translation_api.py
@@ -7,7 +7,6 @@ import shutil
 import subprocess
 import sys
 
-from .utils import expected_http_error
 from jupyterlab_server.translation_utils import (_get_installed_language_pack_locales,
                                  _get_installed_package_locales,
                                  get_display_name,
@@ -16,8 +15,9 @@ from jupyterlab_server.translation_utils import (_get_installed_language_pack_lo
                                  is_valid_locale, merge_locale_data,
                                  translator)
 
-from .utils import maybe_patch_ioloop
-from .utils import validate_request
+from jupyterlab_server.test_utils import expected_http_error
+from jupyterlab_server.test_utils import maybe_patch_ioloop
+from jupyterlab_server.test_utils import validate_request
 
 maybe_patch_ioloop()
 

--- a/tests/test_workspaces_api.py
+++ b/tests/test_workspaces_api.py
@@ -7,8 +7,8 @@ import tornado
 
 from strict_rfc3339 import rfc3339_to_timestamp
 
-from .utils import expected_http_error, maybe_patch_ioloop, big_unicode_string
-from .utils import validate_request
+from jupyterlab_server.test_utils import expected_http_error, maybe_patch_ioloop, big_unicode_string
+from jupyterlab_server.test_utils import validate_request
 
 maybe_patch_ioloop()
 


### PR DESCRIPTION
- Include a `test_utils` file that can be used as a public API
- Add `openapi_spec` and `openapi_spec_dict` conveniences