### PR TITLE
Adds notebook_starts_kernel option to make "canStartKernel" configurable

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -247,6 +247,9 @@ class LabConfig(HasTraits):
     cache_files = Bool(True,
                        help=('Whether to cache files on the server. '
                              'This should be `True` except in dev mode.')).tag(config=True)
+    
+    notebook_starts_kernel = Bool(True,
+                                  help='Whether a notebook can start a kernel automatically.').tag(config=True)
 
     @default('template_dir')
     def _default_template_dir(self):


### PR DESCRIPTION
Adds a new option to make `canStartKernel` configurable for extensions like `notebook-extension`.

For https://github.com/jupyterlab/jupyterlab/issues/12259 .