### PR TITLE
Updates parameter description for notebook_starts_kernel

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -249,7 +249,7 @@ class LabConfig(HasTraits):
                              'This should be `True` except in dev mode.')).tag(config=True)
     
     notebook_starts_kernel = Bool(True,
-                                  help='Whether a notebook can start a kernel automatically.').tag(config=True)
+                                  help='Whether a notebook should start a kernel automatically.').tag(config=True)
 
     @default('template_dir')
     def _default_template_dir(self):

--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -247,6 +247,9 @@ class LabConfig(HasTraits):
     cache_files = Bool(True,
                        help=('Whether to cache files on the server. '
                              'This should be `True` except in dev mode.')).tag(config=True)
+    
+    notebook_starts_kernel = Bool(True,
+                                  help='Whether a notebook can start a kernel automatically.').tag(config=True)
 
     @default('template_dir')
     def _default_template_dir(self):


### PR DESCRIPTION
The parameter now maps to `preferKernel` (notebook _should_ start a kernel) instead of to `canStartKernel` (notebook _can_ start a kernel).

Related to https://github.com/jupyterlab/jupyterlab/issues/12259