### PR TITLE
Audit uses of print

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -3,9 +3,9 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 import os
+import warnings
 from functools import lru_cache
 from urllib.parse import urlparse
-import warnings
 
 from jupyter_server.extension.handler import (
     ExtensionHandlerJinjaMixin,

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -5,6 +5,7 @@
 import os
 from functools import lru_cache
 from urllib.parse import urlparse
+import warnings
 
 from jupyter_server.extension.handler import (
     ExtensionHandlerJinjaMixin,
@@ -255,7 +256,7 @@ def add_handlers(handlers, extension_app):
     allowed_extensions_uris = settings_config.get("allowed_extensions_uris", "")
 
     if (blocked_extensions_uris) and (allowed_extensions_uris):
-        print(
+        warnings.warn(
             "Simultaneous blocked_extensions_uris and allowed_extensions_uris is not supported. Please define only one of those."
         )
         import sys

--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -295,7 +295,8 @@ def _get_overrides(app_settings_dir):
                     path_overrides = json.load(fid)
                 for plugin_id, config in path_overrides.items():
                     recursive_update(overrides.setdefault(plugin_id, {}), config)
-                print(overrides_path, overrides)
+                self.log.debug(f"Overriding with settings from {overrides_path}")
+                self.log.debug(overrides)
             except Exception as e:
                 error = e
 

--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -295,8 +295,6 @@ def _get_overrides(app_settings_dir):
                     path_overrides = json.load(fid)
                 for plugin_id, config in path_overrides.items():
                     recursive_update(overrides.setdefault(plugin_id, {}), config)
-                self.log.debug(f"Overriding with settings from {overrides_path}")
-                self.log.debug(overrides)
             except Exception as e:
                 error = e
 

--- a/jupyterlab_server/workspaces_app.py
+++ b/jupyterlab_server/workspaces_app.py
@@ -1,8 +1,8 @@
 """A workspace management CLI"""
 import json
 import sys
-from pathlib import Path
 import warnings
+from pathlib import Path
 
 from jupyter_core.application import JupyterApp
 from traitlets import Bool, Unicode

--- a/jupyterlab_server/workspaces_app.py
+++ b/jupyterlab_server/workspaces_app.py
@@ -2,6 +2,7 @@
 import json
 import sys
 from pathlib import Path
+import warnings
 
 from jupyter_core.application import JupyterApp
 from traitlets import Bool, Unicode
@@ -85,7 +86,7 @@ class WorkspaceExportApp(JupyterApp, LabConfig):
 
     def start(self):
         if len(self.extra_args) > 1:
-            print("Too many arguments were provided for workspace export.")
+            warnings.warn("Too many arguments were provided for workspace export.")
             self.exit(1)
 
         raw = DEFAULT_WORKSPACE if not self.extra_args else self.extra_args[0]


### PR DESCRIPTION
Use `warnings` where appropriate.

Remove the `print` entirely in `_get_overrides` since we don't have a handle on a logger.

Fixes #260