### PR TITLE
proper setup for the fallback logger

### DIFF
--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -32,7 +32,6 @@ else:
         return " ".join(map(pipes.quote, cmd_list))
 
 
-logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 
 def which(command, env=None):
@@ -92,7 +91,7 @@ class Process:
         if kill_event and kill_event.is_set():
             raise ValueError("Process aborted")
 
-        self.logger = logger = logger or logging.getLogger("jupyterlab")
+        self.logger = logger = logger or self.get_log()
         self._last_line = ""
         if not quiet:
             self.logger.info(f"> {list2cmdline(cmd)}")
@@ -179,6 +178,14 @@ class Process:
         """Clean up the started subprocesses at exit."""
         for proc in list(cls._procs):
             proc.terminate()
+
+    def get_log(self):
+        if hasattr(self, 'logger') and self.logger:
+            return self.logger
+        # fallback logger
+        self.logger = logging.getLogger("jupyterlab")
+        self.logger.setLevel(logging.INFO)
+        return self.logger
 
 
 class WatchHelper(Process):

--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -32,8 +32,6 @@ else:
         return " ".join(map(pipes.quote, cmd_list))
 
 
-
-
 def which(command, env=None):
     """Get the full path to a command.
 
@@ -180,7 +178,7 @@ class Process:
             proc.terminate()
 
     def get_log(self):
-        if hasattr(self, 'logger') and self.logger:
+        if hasattr(self, "logger") and self.logger:
             return self.logger
         # fallback logger
         self.logger = logging.getLogger("jupyterlab")


### PR DESCRIPTION
fix for #268 

the previous code was setting the log level of the root logger, and creating a fallback "jupyterlab" logger that inherits from root. also this was being set outside of any function/method so just by importing the file the log level changed.

since the root logger is not actually used, its better to set the level directly on the fallback logger and only if the passed on logger is not available which shouldn't happen anyway. 