### PR TITLE
Add `jupyter-lsp` to dependencies list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "jinja2>=3.0.3",
   "json5",
   "jsonschema>=3.0.1",
+  "jupyter-lsp",
   "jupyter_server>=1.8,<2",
   "packaging",
   "requests",


### PR DESCRIPTION
This is a part of the ongoing effort (https://github.com/jupyterlab/team-compass/issues/148, https://github.com/jupyter-server/team-compass/issues/30) to support LSP in core JupyterLab. 
