### PR TITLE
raise jupyter_server pin to include 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ test = [
   "codecov",
   "ipykernel",
   "jupyter_server[test]",
-  "openapi_core>=0.14.2",
+  # openapi_core 0.15.0 alpha is not working
+  "openapi_core~=0.14.2",
   "openapi-spec-validator<0.5",
   "pytest>=5.3.2",
   "pytest-console-scripts",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "jinja2>=3.0.3",
   "json5",
   "jsonschema>=3.0.1",
-  "jupyter_server>=1.8,<2",
+  "jupyter_server>=1.8,<3",
   "packaging",
   "requests",
 ]


### PR DESCRIPTION
This raises the ceiling on JupyterLab Server's jupyter_server dependency.

This enables folks to test Jupyter Server 2.0 with JupyterLab 4.0.

cc @fcollonval 