### PR TITLE
Don't change language environment variable

### DIFF
--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -13,7 +13,7 @@ from jupyter_server.services.config.manager import ConfigManager, recursive_upda
 from tornado import web
 
 from .server import APIHandler, tz
-from .translation_utils import DEFAULT_LOCALE, L10N_SCHEMA_NAME, is_valid_locale
+from .translation_utils import DEFAULT_LOCALE, SYS_LOCALE, L10N_SCHEMA_NAME, is_valid_locale
 
 # The JupyterLab settings file extension.
 SETTINGS_EXTENSION = ".jupyterlab-settings"
@@ -454,12 +454,14 @@ class SchemaHandler(APIHandler):
                 labextensions_path=self.labextensions_path,
             )
         except web.HTTPError as e:
-            schema_warning = "Missing or misshappen translation settings schema:\n%s"
+            schema_warning = "Missing or misshapen translation settings schema:\n%s"
             self.log.warning(schema_warning % str(e))
 
             settings = {}
 
-        current_locale = settings.get("settings", {}).get("locale", DEFAULT_LOCALE)
+        current_locale = settings.get("settings", {}).get("locale") or SYS_LOCALE
+        if current_locale == "default":
+            current_locale = SYS_LOCALE
         if not is_valid_locale(current_locale):
             current_locale = DEFAULT_LOCALE
 

--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -13,7 +13,7 @@ from jupyter_server.services.config.manager import ConfigManager, recursive_upda
 from tornado import web
 
 from .server import APIHandler, tz
-from .translation_utils import DEFAULT_LOCALE, SYS_LOCALE, L10N_SCHEMA_NAME, is_valid_locale
+from .translation_utils import DEFAULT_LOCALE, L10N_SCHEMA_NAME, SYS_LOCALE, is_valid_locale
 
 # The JupyterLab settings file extension.
 SETTINGS_EXTENSION = ".jupyterlab-settings"

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -591,7 +591,7 @@ class translator:  # noqa
     Translations manager.
     """
 
-    _TRANSLATORS = {}
+    _TRANSLATORS: Dict[str, TranslationBundle] = {}
     _LOCALE = SYS_LOCALE
 
     @staticmethod

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -125,13 +125,13 @@ def _get_installed_package_locales():
 
 # --- Helpers
 # ----------------------------------------------------------------------------
-def is_valid_locale(locale: str) -> bool:
+def is_valid_locale(locale_: str) -> bool:
     """
-    Check if a `locale` value is valid.
+    Check if a `locale_` value is valid.
 
     Parameters
     ----------
-    locale: str
+    locale_: str
         Language locale code.
 
     Notes
@@ -150,12 +150,12 @@ def is_valid_locale(locale: str) -> bool:
     - Brazilian German: "de_BR"
     """
     # Add exception for Norwegian
-    if locale == "no_NO":
+    if locale_ == "no_NO":
         return True
 
     valid = False
     try:
-        babel.Locale.parse(locale)
+        babel.Locale.parse(locale_)
         valid = True
     except (babel.core.UnknownLocaleError, ValueError):
         pass
@@ -163,25 +163,25 @@ def is_valid_locale(locale: str) -> bool:
     return valid
 
 
-def get_display_name(locale: str, display_locale: str = DEFAULT_LOCALE) -> str:
+def get_display_name(locale_: str, display_locale: str = DEFAULT_LOCALE) -> str:
     """
     Return the language name to use with a `display_locale` for a given language locale.
 
     Parameters
     ----------
-    locale: str
+    locale_: str
         The language name to use.
     display_locale: str, optional
-        The language to display the `locale`.
+        The language to display the `locale_`.
 
     Returns
     -------
     str
-        Localized `locale` and capitalized language name using `display_locale` as language.
+        Localized `locale_` and capitalized language name using `display_locale` as language.
     """
-    locale = locale if is_valid_locale(locale) else DEFAULT_LOCALE
+    locale_ = locale_ if is_valid_locale(locale_) else DEFAULT_LOCALE
     display_locale = display_locale if is_valid_locale(display_locale) else DEFAULT_LOCALE
-    loc = babel.Locale.parse(locale)
+    loc = babel.Locale.parse(locale_)
     display_name = loc.get_display_name(display_locale)
     if display_name:
         display_name = display_name[0].upper() + display_name[1:]
@@ -225,7 +225,7 @@ def merge_locale_data(language_pack_locale_data, package_locale_data):
     return result
 
 
-def get_installed_packages_locale(locale: str) -> Tuple[dict, str]:
+def get_installed_packages_locale(locale_: str) -> Tuple[dict, str]:
     """
     Get all jupyterlab extensions installed that contain locale data.
 
@@ -259,10 +259,10 @@ def get_installed_packages_locale(locale: str) -> Tuple[dict, str]:
             except Exception:
                 messages.append(traceback.format_exc())
 
-            if locale.lower() in locales:
+            if locale_.lower() in locales:
                 locale_json_path = os.path.join(
                     locale_path,
-                    locales[locale.lower()],
+                    locales[locale_.lower()],
                     LC_MESSAGES_DIR,
                     f"{package_name}.json",
                 )
@@ -302,11 +302,11 @@ def get_language_packs(display_locale: str = DEFAULT_LOCALE) -> Tuple[dict, str]
         invalid_locales = []
         valid_locales = []
         messages = []
-        for locale in found_locales:
-            if is_valid_locale(locale):
-                valid_locales.append(locale)
+        for locale_ in found_locales:
+            if is_valid_locale(locale_):
+                valid_locales.append(locale_)
             else:
-                invalid_locales.append(locale)
+                invalid_locales.append(locale_)
 
         display_locale = display_locale if display_locale in valid_locales else DEFAULT_LOCALE
         locales = {
@@ -315,10 +315,10 @@ def get_language_packs(display_locale: str = DEFAULT_LOCALE) -> Tuple[dict, str]
                 "nativeName": get_display_name(DEFAULT_LOCALE, DEFAULT_LOCALE),
             }
         }
-        for locale in valid_locales:
-            locales[locale] = {
-                "displayName": get_display_name(locale, display_locale),
-                "nativeName": get_display_name(locale, locale),
+        for locale_ in valid_locales:
+            locales[locale_] = {
+                "displayName": get_display_name(locale_, display_locale),
+                "nativeName": get_display_name(locale_, locale_),
             }
 
         if invalid_locales:
@@ -327,9 +327,9 @@ def get_language_packs(display_locale: str = DEFAULT_LOCALE) -> Tuple[dict, str]
     return locales, "\n".join(messages)
 
 
-def get_language_pack(locale: str) -> tuple:
+def get_language_pack(locale_: str) -> tuple:
     """
-    Get a language pack for a given `locale` and update with any installed
+    Get a language pack for a given `locale_` and update with any installed
     package locales.
 
     Returns
@@ -344,12 +344,12 @@ def get_language_pack(locale: str) -> tuple:
     information, which seems to be defined on interpreter startup.
     """
     found_locales, message = _get_installed_language_pack_locales()
-    found_packages_locales, message = get_installed_packages_locale(locale)
+    found_packages_locales, message = get_installed_packages_locale(locale_)
     locale_data = {}
     messages = message.split("\n")
-    if not message and is_valid_locale(locale):
-        if locale in found_locales:
-            path = found_locales[locale]
+    if not message and is_valid_locale(locale_):
+        if locale_ in found_locales:
+            path = found_locales[locale_]
             for root, __, files in os.walk(path, topdown=False):
                 for name in files:
                     if name.endswith(".json"):
@@ -383,28 +383,28 @@ class TranslationBundle:
     Translation bundle providing gettext translation functionality.
     """
 
-    def __init__(self, domain: str, locale: str):
+    def __init__(self, domain: str, locale_: str):
         """Initialize the bundle."""
         self._domain = domain
-        self._locale = locale
+        self._locale = locale_
         self._translator = gettext.NullTranslations()
 
-        self.update_locale(locale)
+        self.update_locale(locale_)
 
-    def update_locale(self, locale: str) -> None:
+    def update_locale(self, locale_: str) -> None:
         """
         Update the locale.
 
         Parameters
         ----------
-        locale: str
+        locale_: str
             The language name to use.
         """
         # TODO: Need to handle packages that provide their own .mo files
-        self._locale = locale
+        self._locale = locale_
         localedir = None
-        if locale != DEFAULT_LOCALE:
-            language_pack_module = f"jupyterlab_language_pack_{locale}"
+        if locale_ != DEFAULT_LOCALE:
+            language_pack_module = f"jupyterlab_language_pack_{locale_}"
             try:
                 mod = importlib.import_module(language_pack_module)
                 assert mod.__file__ is not None  # noqa
@@ -610,23 +610,23 @@ class translator:  # noqa
         return domain.replace("-", "_")
 
     @classmethod
-    def set_locale(cls, locale: str) -> None:
+    def set_locale(cls, locale_: str) -> None:
         """
         Set locale for the translation bundles based on the settings.
 
         Parameters
         ----------
-        locale: str
+        locale_: str
             The language name to use.
         """
-        if locale == cls._LOCALE:
+        if locale_ == cls._LOCALE:
             # Nothing to do bail early
             return
 
-        if is_valid_locale(locale):
-            cls._LOCALE = locale
+        if is_valid_locale(locale_):
+            cls._LOCALE = locale_
             for _, bundle in cls._TRANSLATORS.items():
-                bundle.update_locale(locale)
+                bundle.update_locale(locale_)
 
     @classmethod
     def load(cls, domain: str) -> TranslationBundle:

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -158,6 +158,7 @@ def is_valid_locale(locale_: str) -> bool:
         babel.Locale.parse(locale_)
         valid = True
     except (babel.core.UnknownLocaleError, ValueError):
+        # Expected error if the locale is unknown
         pass
 
     return valid

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -653,7 +653,7 @@ class translator:  # noqa
             trans = TranslationBundle(norm_domain, cls._LOCALE)
             cls._TRANSLATORS[norm_domain] = trans
 
-        return trans  # type:ignore
+        return trans
 
     @staticmethod
     def _translate_schema_strings(

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -413,7 +413,9 @@ class TranslationBundle:
                 # no-op
                 pass
 
-        self._translator = gettext.translation(self._domain, localedir=localedir, languages=(self._locale, ), fallback=True)
+        self._translator = gettext.translation(
+            self._domain, localedir=localedir, languages=(self._locale,), fallback=True
+        )
 
     def gettext(self, msgid: str) -> str:
         """

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -387,6 +387,7 @@ class TranslationBundle:
         """Initialize the bundle."""
         self._domain = domain
         self._locale = locale
+        self._translator = gettext.NullTranslations()
 
         self.update_locale(locale)
 
@@ -412,7 +413,7 @@ class TranslationBundle:
                 # no-op
                 pass
 
-        gettext.bindtextdomain(self._domain, localedir=localedir)
+        self._translator = gettext.translation(self._domain, localedir=localedir, languages=(self._locale, ), fallback=True)
 
     def gettext(self, msgid: str) -> str:
         """
@@ -428,7 +429,7 @@ class TranslationBundle:
         str
             The translated string.
         """
-        return gettext.dgettext(self._domain, msgid)
+        return self._translator.dgettext(self._domain, msgid)
 
     def ngettext(self, msgid: str, msgid_plural: str, n: int) -> str:
         """
@@ -448,7 +449,7 @@ class TranslationBundle:
         str
             The translated string.
         """
-        return gettext.dngettext(self._domain, msgid, msgid_plural, n)
+        return self._translator.ngettext(msgid, msgid_plural, n)
 
     def pgettext(self, msgctxt: str, msgid: str) -> str:
         """
@@ -469,9 +470,9 @@ class TranslationBundle:
         # Python 3.7 or lower does not offer translations based on context.
         # On these versions `pgettext` falls back to `gettext`
         if PY37_OR_LOWER:
-            translation = gettext.dgettext(self._domain, msgid)
+            translation = self._translator.gettext(msgid)
         else:
-            translation = gettext.dpgettext(self._domain, msgctxt, msgid)
+            translation = self._translator.pgettext(msgctxt, msgid)
 
         return translation
 
@@ -498,9 +499,9 @@ class TranslationBundle:
         # Python 3.7 or lower does not offer translations based on context.
         # On these versions `npgettext` falls back to `ngettext`
         if PY37_OR_LOWER:
-            translation = gettext.dngettext(self._domain, msgid, msgid_plural, n)
+            translation = self._translator.ngettext(msgid, msgid_plural, n)
         else:
-            translation = gettext.dnpgettext(self._domain, msgctxt, msgid, msgid_plural, n)
+            translation = self._translator.npgettext(msgctxt, msgid, msgid_plural, n)
 
         return translation
 
@@ -713,6 +714,6 @@ class translator:  # noqa
         )
 
         new_schema = schema.copy()
-        translator._translate_schema_strings(translations, schema.copy())
+        translator._translate_schema_strings(translations, new_schema)
 
         return new_schema

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -432,7 +432,7 @@ class TranslationBundle:
         str
             The translated string.
         """
-        return self._translator.dgettext(self._domain, msgid)
+        return self._translator.gettext(msgid)
 
     def ngettext(self, msgid: str, msgid_plural: str, n: int) -> str:
         """

--- a/jupyterlab_server/translations_handler.py
+++ b/jupyterlab_server/translations_handler.py
@@ -22,6 +22,7 @@ from .translation_utils import (
 
 class TranslationsHandler(SchemaHandler):
     """An API handler for translations."""
+
     @tornado.web.authenticated
     async def get(self, locale=None):
         """

--- a/jupyterlab_server/translations_handler.py
+++ b/jupyterlab_server/translations_handler.py
@@ -12,10 +12,10 @@ import tornado
 
 from .settings_utils import SchemaHandler
 from .translation_utils import (
+    SYS_LOCALE,
     get_language_pack,
     get_language_packs,
     is_valid_locale,
-    SYS_LOCALE,
     translator,
 )
 
@@ -41,9 +41,7 @@ class TranslationsHandler(SchemaHandler):
             if locale is None:
                 data, message = await current_loop.run_in_executor(
                     None,
-                    partial(
-                        get_language_packs, display_locale=self.get_current_locale()
-                    ),
+                    partial(get_language_packs, display_locale=self.get_current_locale()),
                 )
             else:
                 locale = locale or SYS_LOCALE

--- a/jupyterlab_server/translations_handler.py
+++ b/jupyterlab_server/translations_handler.py
@@ -21,6 +21,7 @@ from .translation_utils import (
 
 
 class TranslationsHandler(SchemaHandler):
+    """An API handler for translations."""
     @tornado.web.authenticated
     async def get(self, locale=None):
         """

--- a/jupyterlab_server/translations_handler.py
+++ b/jupyterlab_server/translations_handler.py
@@ -6,36 +6,52 @@ Translation handler.
 
 import json
 import traceback
+from functools import partial
 
 import tornado
-from tornado import gen
 
 from .settings_utils import SchemaHandler
-from .translation_utils import get_language_pack, get_language_packs, is_valid_locale, translator
+from .translation_utils import (
+    get_language_pack,
+    get_language_packs,
+    is_valid_locale,
+    SYS_LOCALE,
+    translator,
+)
 
 
 class TranslationsHandler(SchemaHandler):
-    """Translation handler."""
-
-    @gen.coroutine
     @tornado.web.authenticated
-    def get(self, locale=""):
+    async def get(self, locale=None):
         """
         Get installed language packs.
+
+        If `locale` is equals to "default", the default locale will be used.
 
         Parameters
         ----------
         locale: str, optional
             If no locale is provided, it will list all the installed language packs.
-            Default is `""`.
+            Default is `None`.
         """
         data: dict
         data, message = {}, ""
         try:
-            if locale == "":
-                data, message = get_language_packs(display_locale=self.get_current_locale())
+            current_loop = tornado.ioloop.IOLoop.current()
+            if locale is None:
+                data, message = await current_loop.run_in_executor(
+                    None,
+                    partial(
+                        get_language_packs, display_locale=self.get_current_locale()
+                    ),
+                )
             else:
-                data, message = get_language_pack(locale)
+                locale = locale or SYS_LOCALE
+                if locale == "default":
+                    locale = SYS_LOCALE
+                data, message = await current_loop.run_in_executor(
+                    None, partial(get_language_pack, locale)
+                )
                 if data == {} and message == "":
                     if is_valid_locale(locale):
                         message = f"Language pack '{locale}' not installed!"

--- a/tests/test_translation_utils.py
+++ b/tests/test_translation_utils.py
@@ -5,17 +5,10 @@ import sys
 
 from jupyterlab_server.translation_utils import (
     TranslationBundle,
-    _main,
     get_installed_packages_locale,
     get_language_packs,
     translator,
 )
-
-
-def test_transutils_main():
-    sys.argv = ["", "get_language_packs"]
-    _main()
-    sys.argv = [""]
 
 
 def test_get_installed_packages_locale(jp_environ):

--- a/tests/test_translation_utils.py
+++ b/tests/test_translation_utils.py
@@ -1,7 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import sys
 
 from jupyterlab_server.translation_utils import (
     TranslationBundle,


### PR DESCRIPTION
This inverts the logic to by default use the default OS locale to set JupyterLab language (if the associated language pack is installed).

It uses the class API of Python `gettext` instead of the global API as recommended by the Python documentation.