### PR TITLE
Revert "Fix some CodeQL notices"

### DIFF
--- a/jupyterlab_server/server.py
+++ b/jupyterlab_server/server.py
@@ -1,0 +1,21 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+"""Server api."""
+# FIXME TODO Deprecated remove this file for the next major version
+#   Downstream package must import those items from `jupyter_server` directly
+from jupyter_server import _tz as tz
+from jupyter_server.base.handlers import (
+    APIHandler,
+    FileFindHandler,
+    JupyterHandler,
+    json_errors,
+)
+from jupyter_server.extension.serverextension import (
+    GREEN_ENABLED,
+    GREEN_OK,
+    RED_DISABLED,
+    RED_X,
+)
+from jupyter_server.serverapp import ServerApp, aliases, flags
+from jupyter_server.utils import url_escape, url_path_join


### PR DESCRIPTION
Reverts jupyterlab/jupyterlab_server#371 partly to restore `server.py` that may be consumed by downstream package