### PR TITLE
[WIP] Add JSON5 support across the code base

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -3,7 +3,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import json
 import os.path as osp
 from glob import iglob
 from itertools import chain
@@ -13,6 +12,8 @@ from jupyter_core.paths import SYSTEM_CONFIG_PATH, jupyter_config_dir, jupyter_p
 from jupyter_server.services.config.manager import ConfigManager, recursive_update
 from jupyter_server.utils import url_path_join as ujoin
 from traitlets import Bool, HasTraits, List, Unicode, default
+
+from .json_utils import load_json
 
 # -----------------------------------------------------------------------------
 # Module globals
@@ -42,8 +43,7 @@ def get_federated_extensions(labextensions_path):
             iglob(pjoin(ext_dir, "[!@]*", "package.json")),
             iglob(pjoin(ext_dir, "@*", "*", "package.json")),
         ):
-            with open(ext_path, encoding="utf-8") as fid:
-                pkgdata = json.load(fid)
+            pkgdata = load_json(ext_path)
             if pkgdata["name"] not in federated_extensions:
                 data = dict(
                     name=pkgdata["name"],
@@ -58,8 +58,7 @@ def get_federated_extensions(labextensions_path):
                 )
                 install_path = osp.join(osp.dirname(ext_path), "install.json")
                 if osp.exists(install_path):
-                    with open(install_path, encoding="utf-8") as fid:
-                        data["install"] = json.load(fid)
+                    data["install"] = load_json(install_path)
                 federated_extensions[data["name"]] = data
     return federated_extensions
 
@@ -89,8 +88,7 @@ def get_page_config(labextensions_path, app_settings_dir=None, logger=None):  # 
     if app_settings_dir:
         app_page_config = pjoin(app_settings_dir, "page_config.json")
         if osp.exists(app_page_config):
-            with open(app_page_config, encoding="utf-8") as fid:
-                data = json.load(fid)
+            data = load_json(app_page_config)
 
             # Convert lists to dicts
             for key in [disabled_key, "deferredExtensions"]:
@@ -139,8 +137,7 @@ def get_page_config(labextensions_path, app_settings_dir=None, logger=None):  # 
         app_dir = osp.dirname(app_settings_dir)
         package_data_file = pjoin(app_dir, "static", "package.json")
         if osp.exists(package_data_file):
-            with open(package_data_file, encoding="utf-8") as fid:
-                app_data = json.load(fid)
+            app_data = load_json(package_data_file)
             all_ext_data = app_data["jupyterlab"].get("extensionMetadata", {})
             for ext, ext_data in all_ext_data.items():
                 if ext in disabled_by_extensions_all:

--- a/jupyterlab_server/json_utils.py
+++ b/jupyterlab_server/json_utils.py
@@ -1,3 +1,6 @@
+# Copyright (c) Jupyter Development Team.
+# Distributed under the terms of the Modified BSD License.
+
 import pathlib
 from typing import Any, Dict, Union
 

--- a/jupyterlab_server/json_utils.py
+++ b/jupyterlab_server/json_utils.py
@@ -1,0 +1,23 @@
+import pathlib
+from typing import Any, Dict, Union
+
+import json5
+
+
+def load_json(path: Union[pathlib.Path, str]) -> Dict[Any, Any]:
+    """Load a json(5) file and return its contents.
+
+    Assumes the file is UTF-8 encoded.
+
+    Parameters
+    ----------
+    path : Path | str
+        Path of the json or json5 file to load.
+
+    Returns
+    -------
+    Dict[Any, Any]
+        JSON content of the file, deserialized to a dictionary
+    """
+    with open(path, encoding="utf-8") as f:
+        return json5.load(f)

--- a/jupyterlab_server/test_utils.py
+++ b/jupyterlab_server/test_utils.py
@@ -26,10 +26,12 @@ from werkzeug.datastructures import Headers, ImmutableMultiDict
 
 from jupyterlab_server.spec import get_openapi_spec
 
+from .json_utils import load_json
+
 HERE = Path(os.path.dirname(__file__)).resolve()
 
 with open(HERE / "test_data" / "app-settings" / "overrides.json", encoding="utf-8") as fpt:
-    big_unicode_string = json.load(fpt)["@jupyterlab/unicode-extension:plugin"]["comment"]
+    big_unicode_string = load_json(fpt)["@jupyterlab/unicode-extension:plugin"]["comment"]
 
 
 class TornadoOpenAPIRequest:

--- a/jupyterlab_server/translation_utils.py
+++ b/jupyterlab_server/translation_utils.py
@@ -8,7 +8,6 @@ localization data.
 
 import gettext
 import importlib
-import json
 import locale
 import os
 import re
@@ -19,6 +18,8 @@ from typing import Any, Dict, Optional, Pattern, Tuple
 
 import babel
 from packaging.version import parse as parse_version
+
+from .json_utils import load_json
 
 # See compatibility note on `group` keyword in https://docs.python.org/3/library/importlib.metadata.html#entry-points
 if sys.version_info < (3, 10):  # pragma: no cover
@@ -269,8 +270,7 @@ def get_installed_packages_locale(locale_: str) -> Tuple[dict, str]:
                 )
                 if os.path.isfile(locale_json_path):
                     try:
-                        with open(locale_json_path, encoding="utf-8") as fh:
-                            packages_locale_data[package_name] = json.load(fh)
+                        packages_locale_data[package_name] = load_json(locale_json_path)
                     except Exception:
                         messages.append(traceback.format_exc())
 
@@ -356,8 +356,7 @@ def get_language_pack(locale_: str) -> tuple:
                     pkg_name = name.replace(".json", "")
                     json_path = os.path.join(root, name)
                     try:
-                        with open(json_path, encoding="utf-8") as fh:
-                            merged_data = json.load(fh)
+                        merged_data = load_json(json_path)
                     except Exception:
                         messages.append(traceback.format_exc())
 

--- a/jupyterlab_server/workspaces_app.py
+++ b/jupyterlab_server/workspaces_app.py
@@ -12,6 +12,7 @@ from traitlets import Bool, Unicode
 
 from ._version import __version__
 from .config import LabConfig
+from .json_utils import load_json
 from .workspaces_handler import WorkspacesManager
 
 # Default workspace ID
@@ -172,7 +173,7 @@ class WorkspaceImportApp(JupyterApp, LabConfig):
             return file_path.open(encoding="utf-8")
 
     def _validate(self, data):
-        workspace = json.load(data)
+        workspace = load_json(data)
 
         if "data" not in workspace:
             msg = "The `data` field is missing."

--- a/jupyterlab_server/workspaces_handler.py
+++ b/jupyterlab_server/workspaces_handler.py
@@ -16,6 +16,8 @@ from jupyter_server.utils import url_path_join as ujoin
 from tornado import web
 from traitlets.config import LoggingConfigurable
 
+from .json_utils import load_json
+
 # The JupyterLab workspace file extension.
 WORKSPACE_EXTENSION = ".jupyterlab-workspace"
 
@@ -51,12 +53,11 @@ def _load_with_file_times(workspace_path: Path) -> dict:
     metadata with current file stat information
     """
     stat = workspace_path.stat()
-    with workspace_path.open(encoding="utf-8") as fid:
-        workspace = json.load(fid)
-        workspace["metadata"].update(
-            last_modified=tz.utcfromtimestamp(stat.st_mtime).isoformat(),
-            created=tz.utcfromtimestamp(stat.st_ctime).isoformat(),
-        )
+    workspace = load_json(workspace_path)
+    workspace["metadata"].update(
+        last_modified=tz.utcfromtimestamp(stat.st_mtime).isoformat(),
+        created=tz.utcfromtimestamp(stat.st_ctime).isoformat(),
+    )
     return workspace  # type:ignore
 
 


### PR DESCRIPTION
This PR adds support for JSON5 across the code base, closing #377. Everywhere there was a call to `json.load` has been replaced with a json5-compatible loader.

The `load_json` function had to be added to a separate file because it is needed in both `settings_utils.py` and `translation_utils.py`, and if I put it in `settings_utils.py` there's a circular dependency.