### PR TITLE
Add json5 support for page_config.json

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -9,7 +9,7 @@ from glob import iglob
 from itertools import chain
 from os.path import join as pjoin
 
-import json5
+import json5  # type:ignore
 from jupyter_core.paths import SYSTEM_CONFIG_PATH, jupyter_config_dir, jupyter_path
 from jupyter_server.services.config.manager import ConfigManager, recursive_update
 from jupyter_server.utils import url_path_join as ujoin

--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -9,6 +9,7 @@ from glob import iglob
 from itertools import chain
 from os.path import join as pjoin
 
+import json5
 from jupyter_core.paths import SYSTEM_CONFIG_PATH, jupyter_config_dir, jupyter_path
 from jupyter_server.services.config.manager import ConfigManager, recursive_update
 from jupyter_server.utils import url_path_join as ujoin
@@ -78,6 +79,26 @@ def get_static_page_config(app_settings_dir=None, logger=None, level="all"):
     return cm.get("page_config")
 
 
+def load_config(path):
+    """Load either a json5 or a json config file.
+
+    Parameters
+    ----------
+    path : str
+        Path to the file to be loaded
+
+    Returns
+    -------
+    Dict[Any, Any]
+        Dictionary of json or json5 data
+    """
+    with open(path, encoding="utf-8") as fid:
+        if path.endswith('.json5'):
+            return json5.load(fid)
+        else:
+            return json.load(fid)
+
+
 def get_page_config(labextensions_path, app_settings_dir=None, logger=None):  # noqa
     """Get the page config for the application handler"""
     # Build up the full page config
@@ -87,17 +108,20 @@ def get_page_config(labextensions_path, app_settings_dir=None, logger=None):  # 
 
     # Start with the app_settings_dir as lowest priority
     if app_settings_dir:
-        app_page_config = pjoin(app_settings_dir, "page_config.json")
-        if osp.exists(app_page_config):
-            with open(app_page_config, encoding="utf-8") as fid:
-                data = json.load(fid)
+        config_paths = [
+            pjoin(app_settings_dir, "page_config.json5"),
+            pjoin(app_settings_dir, "page_config.json"),
+        ]
+        for path in config_paths:
+            if osp.exists(path):
+                data = load_config(path)
+                # Convert lists to dicts
+                for key in [disabled_key, "deferredExtensions"]:
+                    if key in data:
+                        data[key] = {key: True for key in data[key]}
 
-            # Convert lists to dicts
-            for key in [disabled_key, "deferredExtensions"]:
-                if key in data:
-                    data[key] = {key: True for key in data[key]}
-
-            recursive_update(page_config, data)
+                recursive_update(page_config, data)
+                break
 
     # Get the traitlets config
     static_page_config = get_static_page_config(logger=logger, level="all")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@
 import json
 import os
 
-import json5
+import json5  # type:ignore
 import pytest
 
 from jupyterlab_server.config import get_page_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,17 +4,27 @@
 import json
 import os
 
+import json5
+import pytest
+
 from jupyterlab_server.config import get_page_config
 
 
-def test_get_page_config(tmp_path):
+@pytest.mark.parametrize(
+    "lib,extension",
+    (
+        (json, "json"),
+        (json5, "json5"),
+    ),
+)
+def test_get_page_config(tmp_path, lib, extension):
     labext_path = [os.path.join(tmp_path, "ext")]
     settings_path = os.path.join(tmp_path, "settings")
     os.mkdir(settings_path)
 
-    with open(os.path.join(settings_path, "page_config.json"), "w") as fid:
+    with open(os.path.join(settings_path, f"page_config.{extension}"), "w") as fid:
         data = dict(deferredExtensions=["foo"])
-        json.dump(data, fid)
+        lib.dump(data, fid)
 
     static_dir = os.path.join(tmp_path, "static")
     os.mkdir(static_dir)


### PR DESCRIPTION
Closes #377.

Following on from [this issue](https://github.com/jupyterlab/jupyterlab_server/issues/377), the discussion [here](https://github.com/jupyterlab/jupyterlab_server/pull/378), and a discussion from the [jupyter_server team meeting](https://github.com/jupyter-server/team-compass/issues/45#issuecomment-1471227025), this PR adds json5 support for `page_config.json`. `json5` is _only_ used to load the config if a `page_config.json5` is found to avoid incurring a performance overhead for users who just want to use `json`. An existing test was modified to provide coverage for this.