### PR TITLE
Set Cache-control immutable for static files

### DIFF
--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -3,11 +3,15 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
+from glob import glob
+from os.path import relpath
+
 from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinjaMixin
+from jupyter_server.utils import url_path_join as ujoin
 from traitlets import Dict, Integer, Unicode, observe
 
 from ._version import __version__
-from .handlers import LabConfig, LabFileFindHandler, add_handlers
+from .handlers import LabConfig, add_handlers
 
 
 class LabServerApp(ExtensionAppJinjaMixin, LabConfig, ExtensionApp):
@@ -97,10 +101,26 @@ class LabServerApp(ExtensionAppJinjaMixin, LabConfig, ExtensionApp):
             )
             setattr(self, new_attr, change.new)
 
-    def _prepare_settings(self):
-        """Initialize the app."""
-        super()._prepare_settings()
-        self.serverapp.web_app.settings.update({"static_handler_class": LabFileFindHandler})
+    def initialize_settings(self):
+        """Initialize the settings:
+
+        set the static files as immutable, since they should have all hashed name.
+        """
+        immutable_cache = set(self.settings.get("static_immutable_cache", []))
+
+        # Set lab static files as immutables
+        immutable_cache.add(self.static_url_prefix)
+
+        # Set extensions static files as immutables
+        for extension_path in self.labextensions_path + self.extra_labextensions_path:
+            extensions_url = [
+                ujoin(self.labextensions_url, relpath(path, extension_path))
+                for path in glob(f'{extension_path}/**/static', recursive=True)
+            ]
+
+            immutable_cache.update(extensions_url)
+
+        self.settings.update({"static_immutable_cache": list(immutable_cache)})
 
     def initialize_templates(self):
         """Initialize templates."""

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -7,7 +7,7 @@ from jupyter_server.extension.application import ExtensionApp, ExtensionAppJinja
 from traitlets import Dict, Integer, Unicode, observe
 
 from ._version import __version__
-from .handlers import LabConfig, add_handlers
+from .handlers import LabConfig, LabFileFindHandler, add_handlers
 
 
 class LabServerApp(ExtensionAppJinjaMixin, LabConfig, ExtensionApp):
@@ -96,6 +96,13 @@ class LabServerApp(ExtensionAppJinjaMixin, LabConfig, ExtensionApp):
                 )
             )
             setattr(self, new_attr, change.new)
+
+    def _prepare_settings(self):
+        """ Initialize the app. """
+        super()._prepare_settings()
+        self.serverapp.web_app.settings.update({
+            "static_handler_class": LabFileFindHandler
+        })
 
     def initialize_templates(self):
         """Initialize templates."""

--- a/jupyterlab_server/app.py
+++ b/jupyterlab_server/app.py
@@ -98,11 +98,9 @@ class LabServerApp(ExtensionAppJinjaMixin, LabConfig, ExtensionApp):
             setattr(self, new_attr, change.new)
 
     def _prepare_settings(self):
-        """ Initialize the app. """
+        """Initialize the app."""
         super()._prepare_settings()
-        self.serverapp.web_app.settings.update({
-            "static_handler_class": LabFileFindHandler
-        })
+        self.serverapp.web_app.settings.update({"static_handler_class": LabFileFindHandler})
 
     def initialize_templates(self):
         """Initialize templates."""

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -174,6 +174,15 @@ class NotFoundHandler(LabHandler):
         page_config["notFoundUrl"] = self.request.path
         return page_config
 
+class LabFileFindHandler(FileFindHandler):
+    """ A handler to cache static files """
+
+    def set_headers(self):
+        """Set the headers."""
+        super().set_headers()
+        # keep the "no-cache" settings for expected files
+        if not any(self.request.path.startswith(path) for path in self.no_cache_paths):
+            self.set_header("Cache-Control", "public, max-age=31536000, immutable")
 
 def add_handlers(handlers, extension_app):  # noqa
     """Add the appropriate handlers to the web app."""

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -175,17 +175,6 @@ class NotFoundHandler(LabHandler):
         return page_config
 
 
-class LabFileFindHandler(FileFindHandler):
-    """A handler to cache static files"""
-
-    def set_headers(self):
-        """Set the headers."""
-        super().set_headers()
-        # keep the "no-cache" settings for expected files
-        if not any(self.request.path.startswith(path) for path in self.no_cache_paths):
-            self.set_header("Cache-Control", "public, max-age=31536000, immutable")
-
-
 def add_handlers(handlers, extension_app):  # noqa
     """Add the appropriate handlers to the web app."""
     # Normalize directories.

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -174,8 +174,9 @@ class NotFoundHandler(LabHandler):
         page_config["notFoundUrl"] = self.request.path
         return page_config
 
+
 class LabFileFindHandler(FileFindHandler):
-    """ A handler to cache static files """
+    """A handler to cache static files"""
 
     def set_headers(self):
         """Set the headers."""
@@ -183,6 +184,7 @@ class LabFileFindHandler(FileFindHandler):
         # keep the "no-cache" settings for expected files
         if not any(self.request.path.startswith(path) for path in self.no_cache_paths):
             self.set_header("Cache-Control", "public, max-age=31536000, immutable")
+
 
 def add_handlers(handlers, extension_app):  # noqa
     """Add the appropriate handlers to the web app."""


### PR DESCRIPTION
As mentioned in https://github.com/jupyterlab/jupyterlab/issues/10273 and https://github.com/jupyterlab/jupyterlab/issues/14124, JupyterLab now uses hashes for the javascript assets.

There is probably no need to keep the `Cache-control=no-cache` anymore, as the hash should ensure that the cached file is the expected one.

~~This PR adds a handler for static files and uses it in tornado settings.~~

Thanks to @fcollonval and @davidbrochart too.

**EDIT:**
This PR uses the web app settings key included in https://github.com/jupyter-server/jupyter_server/pull/1268