### PR TITLE
Add repository info when getting federated extensions

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -60,6 +60,11 @@ def get_federated_extensions(labextensions_path: list[str]) -> dict[str, Any]:
                     dependencies=pkgdata.get("dependencies", dict()),
                     jupyterlab=pkgdata.get("jupyterlab", dict()),
                 )
+
+                # Add repository info if available
+                if "repository" in pkgdata and "url" in pkgdata.get("repository", {}):
+                    data["repository"] = dict(url=pkgdata.get("repository").get("url"))
+
                 install_path = osp.join(osp.dirname(ext_path), "install.json")
                 if osp.exists(install_path):
                     with open(install_path, encoding="utf-8") as fid:


### PR DESCRIPTION
## References

### https://github.com/jupyterlab/jupyterlab_server/issues/416 Add repository url to extension info

## Code changes

- Adds missing `repository` field to values returned by `get_federated_extensions` if it's available in relevant package.json (and if it contains a "url" field)