### PR TITLE
Align JSON schema validator with one used on the frontend

### DIFF
--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -10,7 +10,7 @@ from glob import glob
 from typing import Any
 
 import json5  # type:ignore[import-untyped]
-from jsonschema import Draft4Validator as Validator
+from jsonschema import Draft7Validator as Validator
 from jsonschema import ValidationError
 from jupyter_server import _tz as tz
 from jupyter_server.base.handlers import APIHandler


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyterlab/issues/15391

For an overview of changes see to v07 compared to v06 see:
- https://json-schema.org/draft-06/json-schema-release-notes
- https://json-schema.org/draft-07/json-hyper-schema-release-notes

This should be safe to release because the frontend JSON schema form was already enforcing v07 as discussed in https://github.com/jupyterlab/jupyterlab/issues/15391#issuecomment-1806886823.