### PR TITLE
Fix link-rot for Swagger view of OpenAPI spec

### DIFF
--- a/jupyterlab_server/rest-api.yml
+++ b/jupyterlab_server/rest-api.yml
@@ -1,4 +1,4 @@
-# see me at: http://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterlab/jupyterlab_server/master/docs/rest-api.yml#/default
+# see me at: https://petstore.swagger.io/?url=https://raw.githubusercontent.com/jupyterlab/jupyterlab_server/main/jupyterlab_server/rest-api.yml#/default
 openapi: "3.0.3"
 info:
   title: JupyterLab Server


### PR DESCRIPTION
Was the spec ever in `/docs/`? Also, the primary branch name changed, and GitHub's attitude about `master -> main` is "hey, we made a new preference and put out a press release; all our work here is done."