### PR TITLE
URL Incorrect path Issue

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -179,6 +179,7 @@ class NotFoundHandler(LabHandler):
     @lru_cache  # noqa: B019
     def get_page_config(self) -> dict[str, Any]:
         """Get the page config."""
+        # Making a copy of the page_config to ensure changes do not affect the original
         page_config = super().get_page_config().copy()
         page_config["notFoundUrl"] = self.request.path
         return page_config

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -179,7 +179,7 @@ class NotFoundHandler(LabHandler):
     @lru_cache  # noqa: B019
     def get_page_config(self) -> dict[str, Any]:
         """Get the page config."""
-        page_config = super().get_page_config()
+        page_config = super().get_page_config().copy()
         page_config["notFoundUrl"] = self.request.path
         return page_config
 


### PR DESCRIPTION
#**Issue No.** [JuyterLab-#12768](https://github.com/jupyterlab/jupyterlab/issues/12768)

**Solution:**

This issue is because of directly referencing the dictionary object instead of creating a copy in Python. This leads to unintended shared state, where modifications made to the dictionary in one part of the code affect other references to the same dictionary object.
https://github.com/jupyterlab/jupyterlab_server/blob/8b8182de949a416423b9cb15c53a19ceb89bd8c5/jupyterlab_server/handlers.py#L182

This makes a direct access to the page_config dictionary object, meaning that appending the notFoundUrl to this page_config persists throughout the instance. As a consequence, accessing the correct URL after this operation continues to trigger the same error mentioning the same path which is captured while accessing the wrong path.
https://github.com/jupyterlab/jupyterlab_server/blob/8b8182de949a416423b9cb15c53a19ceb89bd8c5/jupyterlab_server/handlers.py#L183

So, creating a shallow copy of the object fixes this issue.👇
https://github.com/jupyterlab/jupyterlab_server/blob/3be24ab0e669f4da5e4dc6c641aa7d4fe2e804c3/jupyterlab_server/handlers.py#L182
