### PR TITLE
For v2 extensions parse entrypoint data

### DIFF
--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -163,6 +163,8 @@ def get_page_config(
             extension["mimeExtension"] = extbuild["mimeExtension"]
         if "style" in extbuild:
             extension["style"] = extbuild["style"]
+        if "version" in extbuild and "entrypoint" in extbuild and extbuild["version"] == '2':
+            extension['entrypoints'] = extbuild["entrypoint"]
         extensions.append(extension)
 
         # If there is disabledExtensions metadata, consume it.

--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -163,8 +163,8 @@ def get_page_config(
             extension["mimeExtension"] = extbuild["mimeExtension"]
         if "style" in extbuild:
             extension["style"] = extbuild["style"]
-        if "version" in extbuild and "entrypoint" in extbuild and extbuild["version"] == "2":
-            extension["entrypoints"] = extbuild["entrypoint"]
+        # FIXME @experimental for plugin with no-code entrypoints.
+        extension["entrypoints"] = extbuild.get("entrypoints")
         extensions.append(extension)
 
         # If there is disabledExtensions metadata, consume it.

--- a/jupyterlab_server/config.py
+++ b/jupyterlab_server/config.py
@@ -163,8 +163,8 @@ def get_page_config(
             extension["mimeExtension"] = extbuild["mimeExtension"]
         if "style" in extbuild:
             extension["style"] = extbuild["style"]
-        if "version" in extbuild and "entrypoint" in extbuild and extbuild["version"] == '2':
-            extension['entrypoints'] = extbuild["entrypoint"]
+        if "version" in extbuild and "entrypoint" in extbuild and extbuild["version"] == "2":
+            extension["entrypoints"] = extbuild["entrypoint"]
         extensions.append(extension)
 
         # If there is disabledExtensions metadata, consume it.


### PR DESCRIPTION
This change will make entrypoint data available for jupyterlab application.  
It will be consumed for loading the plugins in a no-code way.  Refer https://hackmd.io/DBlDBDszSVSjYK9ieg1mZA