### PR TITLE
Load overrides once, rather than in each settings handler

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -20,6 +20,7 @@ from .config import LabConfig, get_page_config, recursive_update
 from .licenses_handler import LicensesHandler, LicensesManager
 from .listings_handler import ListingsHandler, fetch_listings
 from .settings_handler import SettingsHandler
+from .settings_utils import _get_overrides
 from .themes_handler import ThemesHandler
 from .translations_handler import TranslationsHandler
 from .workspaces_handler import WorkspacesHandler, WorkspacesManager
@@ -227,11 +228,19 @@ def add_handlers(handlers: list[Any], extension_app: LabServerApp) -> None:
 
     # Handle local settings.
     if extension_app.schemas_dir:
+        # Load overrides once, rather than in each copy of the settings handler
+        overrides, error = _get_overrides(extension_app.app_settings_dir)
+
+        if error:
+            overrides_warning = "Failed loading overrides: %s"
+            extension_app.log.warning(overrides_warning, error)
+
         settings_config: dict[str, Any] = {
             "app_settings_dir": extension_app.app_settings_dir,
             "schemas_dir": extension_app.schemas_dir,
             "settings_dir": extension_app.user_settings_dir,
             "labextensions_path": labextensions_path,
+            "overrides": overrides,
         }
 
         # Handle requests for the list of settings. Make slash optional.

--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -25,7 +25,7 @@ class SettingsHandler(ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, SchemaH
         schemas_dir: str,
         settings_dir: str,
         labextensions_path: list[str],
-        overrides: dict[str, Any],
+        overrides: dict[str, Any] | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Initialize the handler."""

--- a/jupyterlab_server/settings_handler.py
+++ b/jupyterlab_server/settings_handler.py
@@ -25,11 +25,12 @@ class SettingsHandler(ExtensionHandlerMixin, ExtensionHandlerJinjaMixin, SchemaH
         schemas_dir: str,
         settings_dir: str,
         labextensions_path: list[str],
+        overrides: dict[str, Any],
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         """Initialize the handler."""
         SchemaHandler.initialize(
-            self, app_settings_dir, schemas_dir, settings_dir, labextensions_path
+            self, app_settings_dir, schemas_dir, settings_dir, labextensions_path, overrides
         )
         ExtensionHandlerMixin.initialize(self, name)
 

--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -448,16 +448,23 @@ class SchemaHandler(APIHandler):
         schemas_dir: str,
         settings_dir: str,
         labextensions_path: list[str] | None,
-        overrides: dict[str, Any],
+        overrides: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         """Initialize the handler."""
         super().initialize(**kwargs)
+        error = None
+        if not overrides:
+            overrides, error = _get_overrides(app_settings_dir)
         self.overrides = overrides
         self.app_settings_dir = app_settings_dir
         self.schemas_dir = schemas_dir
         self.settings_dir = settings_dir
         self.labextensions_path = labextensions_path
+
+        if error:
+            overrides_warning = "Failed loading overrides: %s"
+            self.log.warning(overrides_warning, error)
 
     def get_current_locale(self) -> str:
         """

--- a/jupyterlab_server/settings_utils.py
+++ b/jupyterlab_server/settings_utils.py
@@ -448,19 +448,16 @@ class SchemaHandler(APIHandler):
         schemas_dir: str,
         settings_dir: str,
         labextensions_path: list[str] | None,
+        overrides: dict[str, Any],
         **kwargs: Any,
     ) -> None:
         """Initialize the handler."""
         super().initialize(**kwargs)
-        self.overrides, error = _get_overrides(app_settings_dir)
+        self.overrides = overrides
         self.app_settings_dir = app_settings_dir
         self.schemas_dir = schemas_dir
         self.settings_dir = settings_dir
         self.labextensions_path = labextensions_path
-
-        if error:
-            overrides_warning = "Failed loading overrides: %s"
-            self.log.warning(overrides_warning, error)
 
     def get_current_locale(self) -> str:
         """

--- a/tests/test_settings_api.py
+++ b/tests/test_settings_api.py
@@ -30,9 +30,13 @@ async def test_get_settings_overrides_dicts(jp_fetch, labserverapp):
 
 
 @pytest.mark.parametrize("ext", ["json", "json5"])
-async def test_get_settings_overrides_d_dicts(jp_fetch, labserverapp, ext):
+async def test_get_settings_overrides_d_dicts(
+    jp_fetch, jp_serverapp, make_labserver_extension_app, ext
+):
     # Check that values that are dictionaries in overrides.d/*.json are
     # merged with the schema.
+    labserverapp = make_labserver_extension_app()
+    labserverapp._link_jupyter_server_extension(jp_serverapp)
     id = "@jupyterlab/apputils-extension:themes"
     overrides_d = Path(labserverapp.app_settings_dir) / "overrides.d"
     overrides_d.mkdir(exist_ok=True, parents=True)
@@ -41,6 +45,8 @@ async def test_get_settings_overrides_d_dicts(jp_fetch, labserverapp, ext):
         if ext == "json5":
             text += "\n// a comment"
         (overrides_d / f"foo-{i}.{ext}").write_text(text, encoding="utf-8")
+    # Initialize labserverapp only after the overrides were created
+    labserverapp.initialize()
     r = await jp_fetch("lab", "api", "settings", id)
     validate_request(r)
     res = r.body.decode()


### PR DESCRIPTION
### References

Fixes https://github.com/jupyterlab/jupyterlab/issues/16355

### Code changes

Previously the `overrides.json` were loaded from disk for each instance of the handler. Now the loading takes part once prior to handler intiialization.

### User-facing changes

When `overrides.json` is present, JupyterLab loads faster.

### Breaking changes

None