### PR TITLE
Add Monthly Downloads Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Build Status](https://github.com/jupyterlab/jupyterlab_server/workflows/Tests/badge.svg?branch=master)](https://github.com/jupyterlab/jupyterlab_server/actions?query=branch%3Amaster+workflow%3A%22Tests%22)
 [![Documentation Status](https://readthedocs.org/projects/jupyterlab-server/badge/?version=stable)](http://jupyterlab-server.readthedocs.io/en/stable/)
-[![jupyterlab-server Downloads Last Month](https://assets.piptrends.com/get-last-month-downloads-badge/jupyterlab-server.svg 'jupyterlab-server Downloads Last Month by pip Trends')](https://piptrends.com/package/jupyterlab-server)
-
+[![jupyterlab-server Downloads Last Month](https://assets.piptrends.com/get-last-month-downloads-badge/jupyterlab-server.svg "jupyterlab-server Downloads Last Month by pip Trends")](https://piptrends.com/package/jupyterlab-server)
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://github.com/jupyterlab/jupyterlab_server/workflows/Tests/badge.svg?branch=master)](https://github.com/jupyterlab/jupyterlab_server/actions?query=branch%3Amaster+workflow%3A%22Tests%22)
 [![Documentation Status](https://readthedocs.org/projects/jupyterlab-server/badge/?version=stable)](http://jupyterlab-server.readthedocs.io/en/stable/)
+[![jupyterlab-server Downloads Last Month](https://assets.piptrends.com/get-last-month-downloads-badge/jupyterlab-server.svg 'jupyterlab-server Downloads Last Month by pip Trends')](https://piptrends.com/package/jupyterlab-server)
+
 
 ## Motivation
 


### PR DESCRIPTION
Added a badge displaying the monthly download count from pip Trends. You can view more details at - https://piptrends.com/package/jupyterlab-server

(If necessary, the link from the badge to the package's pip Trends page can be removed. We just want to showcase a badge we have created.)