### PR TITLE
Add `@web.authenticated` for `ListingsHandler`'s `GET` method

### DIFF
--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -82,7 +82,7 @@ class ListingsHandler(APIHandler):
     # The PeriodicCallback that schedule the call to fetch_listings method.
     pc = None
 
-    @web.authenticated
+    @tornado.web.authenticated
     def get(self, path: str) -> None:
         """Get the listings for the extension manager."""
         self.set_header("Content-Type", "application/json")

--- a/jupyterlab_server/listings_handler.py
+++ b/jupyterlab_server/listings_handler.py
@@ -82,6 +82,7 @@ class ListingsHandler(APIHandler):
     # The PeriodicCallback that schedule the call to fetch_listings method.
     pc = None
 
+    @web.authenticated
     def get(self, path: str) -> None:
         """Get the listings for the extension manager."""
         self.set_header("Content-Type", "application/json")


### PR DESCRIPTION
The listing handler was leaking the configuration (`blocked_extensions_uris`, `allowed_extensions_uris`, `blocked_extensions`, `blocked_extensions`). This should not need an advisory so opening PR directly.