### PR TITLE
Add allow_setup_custom_env_variables flag to page config

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -82,10 +82,13 @@ class LabHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandl
         server_root = self.settings.get("server_root_dir", "")
         server_root = server_root.replace(os.sep, "/")
         base_url = self.settings.get("base_url")
+        server_app = self.settings.get("serverapp")
+        allow_setup_custom_env_variables = server_app.allow_custom_env_variables
 
         # Remove the trailing slash for compatibility with html-webpack-plugin.
         full_static_url = self.static_url_prefix.rstrip("/")
         page_config.setdefault("fullStaticUrl", full_static_url)
+        page_config.setdefault("allow_setup_custom_env_variables", allow_setup_custom_env_variables)
 
         page_config.setdefault("terminalsAvailable", terminals)
         page_config.setdefault("ignorePlugins", [])

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -83,7 +83,7 @@ class LabHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandl
         server_root = server_root.replace(os.sep, "/")
         base_url = self.settings.get("base_url")
         server_app = self.settings.get("serverapp")
-        allow_setup_custom_env_variables = server_app.allow_custom_env_variables
+        allow_setup_custom_env_variables = server_app.allow_setup_custom_env_variables
 
         # Remove the trailing slash for compatibility with html-webpack-plugin.
         full_static_url = self.static_url_prefix.rstrip("/")


### PR DESCRIPTION
This PR is the part of solution of the feature where users can set up custom env variables for a kernel which has not been run yet.
UI is on https://github.com/AnastasiaSliusar/jupyterlab/pull/2

Code changes
This PR includes `allow_setup_custom_env_variables` flag in page config. This flag is used to detect whether a user should see UI for setup custom env variables or not.