### PR TITLE
Add allow_insecure_kernelspec_params to page config

### DIFF
--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -82,6 +82,8 @@ class LabHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandl
         server_root = self.settings.get("server_root_dir", "")
         server_root = server_root.replace(os.sep, "/")
         base_url = self.settings.get("base_url")
+        server_app = self.settings.get("serverapp")
+        allow_insecure_kernelspec_params = server_app.allow_insecure_kernelspec_params
 
         # Remove the trailing slash for compatibility with html-webpack-plugin.
         full_static_url = self.static_url_prefix.rstrip("/")
@@ -91,6 +93,7 @@ class LabHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandl
         page_config.setdefault("ignorePlugins", [])
         page_config.setdefault("serverRoot", server_root)
         page_config["store_id"] = self.application.store_id  # type:ignore[attr-defined]
+        page_config.setdefault("allow_insecure_kernelspec_params", allow_insecure_kernelspec_params)
 
         server_root = os.path.normpath(os.path.expanduser(server_root))
         preferred_path = ""


### PR DESCRIPTION
## References
This work is a part of and in progress as JEP [jupyter/enhancement-proposals#87](https://github.com/jupyter/enhancement-proposals/pull/87).
This PR should be reviewed when the JEP has been accepted

## Code changes
 
This PR includes new flag to page config such as `allow_insecure_kernelspec_params` which indicates that the feature about parameterised kernels can be switched on

## How to use
- Please use this PR together with next PRs:
  https://github.com/jupyterlab/jupyterlab/pull/16487
  https://github.com/jupyter/jupyter_client/pull/1028/
 https://github.com/jupyter-server/jupyter_server/pull/1431
