### PR TITLE
Upgrade Python version in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.13"]
         include:
           - os: windows-latest
             python-version: "3.9"


### PR DESCRIPTION
Tests are failing in #463 due to warnings. As 3.8 is not supported, this is an easy attempt around the test failure.