### PR TITLE
Add documentation for `page_config_hook`

### DIFF
--- a/docs/source/api/handlers.rst
+++ b/docs/source/api/handlers.rst
@@ -15,6 +15,33 @@ Module: :mod:`jupyterlab_server.handlers`
 .. autoclass:: LabHandler
     :members:
 
+.. rubric:: Page config hook
+
+``page_config_hook`` is an optional callable you can provide via the Jupyter Server web application settings to customize the page configuration before it is rendered.
+
+- Where: ``web_app.settings['page_config_hook']``
+- Signature: ``callable(handler, page_config) -> dict``
+    - ``handler``: the active ``LabHandler`` instance
+    - ``page_config``: a dict containing the current page configuration
+- Return: the updated page configuration dict.
+
+Example (in a server extension ``load_jupyter_server_extension`` or ``_load_jupyter_server_extension``):
+
+.. code-block:: python
+
+        def my_page_config_hook(handler, page_config: dict) -> dict:
+                # Add or override values
+                page_config.setdefault('extraKeys', {})
+                page_config['extraKeys']['hello'] = 'world'
+                return page_config
+
+        def load_jupyter_server_extension(serverapp):
+                web_app = serverapp.web_app
+                # Register the hook once at startup
+                web_app.settings['page_config_hook'] = my_page_config_hook
+
+With this hook set, JupyterLab Server will call it during page configuration assembly, letting you inject or tweak values prior to rendering the index page.
+
 .. autofunction:: add_handlers
 
 .. autofunction:: is_url

--- a/docs/source/api/handlers.rst
+++ b/docs/source/api/handlers.rst
@@ -30,14 +30,12 @@ Example (in a server extension ``load_jupyter_server_extension`` or ``_load_jupy
 .. code-block:: python
 
         def my_page_config_hook(handler, page_config: dict) -> dict:
-                # Add or override values
                 page_config.setdefault('extraKeys', {})
                 page_config['extraKeys']['hello'] = 'world'
                 return page_config
 
         def load_jupyter_server_extension(serverapp):
                 web_app = serverapp.web_app
-                # Register the hook once at startup
                 web_app.settings['page_config_hook'] = my_page_config_hook
 
 With this hook set, JupyterLab Server will call it during page configuration assembly, letting you inject or tweak values prior to rendering the index page.

--- a/docs/source/api/handlers.rst
+++ b/docs/source/api/handlers.rst
@@ -30,13 +30,14 @@ Example (in a server extension ``load_jupyter_server_extension`` or ``_load_jupy
 .. code-block:: python
 
         def my_page_config_hook(handler, page_config: dict) -> dict:
-                page_config.setdefault('extraKeys', {})
-                page_config['extraKeys']['hello'] = 'world'
-                return page_config
+            page_config.setdefault("extraKeys", {})
+            page_config["extraKeys"]["hello"] = "world"
+            return page_config
+
 
         def load_jupyter_server_extension(serverapp):
-                web_app = serverapp.web_app
-                web_app.settings['page_config_hook'] = my_page_config_hook
+            web_app = serverapp.web_app
+            web_app.settings["page_config_hook"] = my_page_config_hook
 
 With this hook set, JupyterLab Server will call it during page configuration assembly, letting you inject or tweak values prior to rendering the index page.
 


### PR DESCRIPTION
`page_config_hook` was added in https://github.com/jupyterlab/jupyterlab_server/pull/220.

However it is not easily discoverable.

So this PR adds it to the documentation, so searching for 'hook' can help find it more easily.