### PR TITLE
Fix CI Failures

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fix-license-header.yml
+++ b/.github/workflows/fix-license-header.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   header-license-fix:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.9", "3.12"]
         include:
           - os: windows-latest
             python-version: "3.9"

--- a/jupyterlab_server/handlers.py
+++ b/jupyterlab_server/handlers.py
@@ -170,7 +170,7 @@ class LabHandler(ExtensionHandlerJinjaMixin, ExtensionHandlerMixin, JupyterHandl
         page_config["treePath"] = tree_path
 
         # Write the template with the config.
-        tpl = self.render_template("index.html", page_config=page_config)  # type:ignore[no-untyped-call]
+        tpl = self.render_template("index.html", page_config=page_config)
         self.write(tpl)
 
 


### PR DESCRIPTION
## Fixes #470

This PR addresses CI failures that have been affecting recent pull requests.

#### 1. Python 3.8 Hatch Installation Failure
```
TypeError: 'type' object is not subscriptable
Error installing hatch.
```
- The CI matrix was using `"3.8"`, but modern versions of `hatch` and its dependencies require Python 3.9+ 
- Changed `"3.8"` to `"3.9"` in the test matrix

#### 2. Unused Type Ignore Comment
Removed the unused `# type: ignore` comment that is no longer needed.

#### 3. Deprecated Ubuntu Runner Causing Job Stalls

- Some jobs were stalling with `Waiting for a runner to pick up this job...` because it was using the deprecated `ubuntu-20.04` runner.
- Updated CodeQL workflow to use ubuntu-latest (currently ubuntu-22.04) for reliable runner availability.