### PR TITLE
Bump Python max version to 3.14 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9", "3.14"]
         include:
           - os: windows-latest
             python-version: "3.9"

--- a/jupyterlab_server/test_utils.py
+++ b/jupyterlab_server/test_utils.py
@@ -167,6 +167,7 @@ def maybe_patch_ioloop() -> None:
         sys.platform.startswith("win")
         and tornado.version_info < (6, 1)
         and sys.version_info >= (3, 8)
+        and sys.version_info < (3, 14)
     ):
         try:
             from asyncio import WindowsProactorEventLoopPolicy, WindowsSelectorEventLoopPolicy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ openapi = [
 test = [
   "hatch",
   "ipykernel",
-  "pytest-jupyter[server]>=0.11.0",
+  "pytest-jupyter[server]>=0.6.2;python_version<\"3.14\"",
+  "pytest-jupyter[server]>=0.11.0;python_version>=\"3.14\"",
   "openapi_core~=0.18.0",
   "openapi-spec-validator>=0.6.0,<0.8.0",
   "sphinxcontrib_spelling",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "jupyter_server>=1.21,<3",
   "packaging>=21.3",
   "requests>=2.31",
+  "jupyter_core>=5.9.0",
 ]
 
 [[project.authors]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "jupyter_server>=1.21,<3",
   "packaging>=21.3",
   "requests>=2.31",
-  "jupyter_core>=5.9.0;python_version>=\"3.14\"",
+  "jupyter_core>=5.9.1;python_version>=\"3.14\"",
 ]
 
 [[project.authors]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
   "jupyter_server>=1.21,<3",
   "packaging>=21.3",
   "requests>=2.31",
-  "jupyter_core>=5.9.0",
+  "jupyter_core>=5.9.0;python_version>=\"3.14\"",
 ]
 
 [[project.authors]]
@@ -72,7 +72,7 @@ openapi = [
 test = [
   "hatch",
   "ipykernel",
-  "pytest-jupyter[server]>=0.6.2",
+  "pytest-jupyter[server]>=0.11.0",
   "openapi_core~=0.18.0",
   "openapi-spec-validator>=0.6.0,<0.8.0",
   "sphinxcontrib_spelling",


### PR DESCRIPTION
Python 3.14 has been released, so this PR updates the CI configuration to include it as the new maximum supported version.