### PR TITLE
Drop use of undocumented `list2cmdline` in favor of `shlex.join`

### DIFF
--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -8,6 +8,7 @@ import atexit
 import logging
 import os
 import re
+import shlex
 import signal
 import subprocess
 import sys
@@ -24,16 +25,6 @@ try:
     import pty
 except ImportError:
     pty = None  # type:ignore[assignment]
-
-if sys.platform == "win32":
-    list2cmdline = subprocess.list2cmdline
-else:
-
-    def list2cmdline(cmd_list: list[str]) -> str:
-        """Shim for list2cmdline on posix."""
-        import shlex
-
-        return " ".join(map(shlex.quote, cmd_list))
 
 
 def which(command: str, env: dict[str, str] | None = None) -> str:
@@ -106,7 +97,7 @@ class Process:
         self.logger = logger or self.get_log()
         self._last_line = ""
         if not quiet:
-            self.logger.info("> %s", list2cmdline(cmd))
+            self.logger.info("> %s", shlex.join(cmd))
         self.cmd = cmd
 
         kwargs = {}

--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -11,7 +11,6 @@ import re
 import shlex
 import signal
 import subprocess
-import sys
 import threading
 import time
 import weakref

--- a/jupyterlab_server/process.py
+++ b/jupyterlab_server/process.py
@@ -26,6 +26,10 @@ except ImportError:
     pty = None  # type:ignore[assignment]
 
 
+# for backward compatibility
+list2cmdline = shlex.join
+
+
 def which(command: str, env: dict[str, str] | None = None) -> str:
     """Get the full path to a command.
 


### PR DESCRIPTION
`shlex.join` was introduced in Python 3.8 and since we require 3.8 or newer we can just use it. `list2cmdline` is Windows-only and not formally documented.

Noticed when looking at https://github.com/jupyterlab/jupyter-builder/issues/48